### PR TITLE
Fix remove-data command

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -76,8 +76,8 @@ clean: ## Clean environment
 .PHONY: remove-data
 remove-data: ## Remove all content
 	@echo "$(RED)==> Removing all content$(RESET)"
-	rm -rf $(VENV_FOLDER) instance/var
-	$(MAKE) install
+	rm -rf instance/var instance/etc/zope.ini
+	$(MAKE) config
 
 # Instance management
 

--- a/backend/news/+fixremovedatacommand.bugfix
+++ b/backend/news/+fixremovedatacommand.bugfix
@@ -1,0 +1,1 @@
+Fix `remove-data` command. @sneridagh


### PR DESCRIPTION
If  `@uvx cookiecutter -f --no-input --config-file instance.yaml gh:plone/cookiecutter-zope-instance` is not run, after deleting the database, the `create-site` command  throws:

```
Traceback (most recent call last):
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/info.py", line 54, in convert
    return datatype(self.value)
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/datatypes.py", line 340, in existing_dirpath
    raise ValueError('The directory named as part of the path %s '
ValueError: The directory named as part of the path /Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/instance/var/filestorage/Data.fs does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/bin/zconsole", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/Zope2/utilities/zconsole.py", line 50, in main
    runscript(namespace.zopeconf, *namespace.scriptargs)
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/Zope2/utilities/zconsole.py", line 13, in runscript
    make_wsgi_app({}, zopeconf)
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/Zope2/Startup/run.py", line 51, in make_wsgi_app
    opts = ZopeWSGIOptions(configfile=zope_conf)()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/Zope2/Startup/options.py", line 84, in __call__
    self.load_configfile()
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/Zope2/Startup/options.py", line 79, in load_configfile
    self.configroot, self.confighandlers = loader.loadURL(
                                           ^^^^^^^^^^^^^^^
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/loader.py", line 153, in loadURL
    return self.loadResource(r)
           ^^^^^^^^^^^^^^^^^^^^
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/loader.py", line 397, in loadResource
    self._parse_resource(sm, resource)
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/loader.py", line 442, in _parse_resource
    parser.parse(matcher)
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/cfgparser.py", line 69, in parse
    section = self.end_section(section, line[2:-1])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/cfgparser.py", line 121, in end_section
    self.context.endSection(
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/loader.py", line 415, in endSection
    sectvalue = matcher.finish()
                ^^^^^^^^^^^^^^^^
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/matcher.py", line 174, in finish
    return self.constuct()
           ^^^^^^^^^^^^^^^
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/matcher.py", line 222, in constuct
    v = v.convert(ci.datatype)
        ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZConfig/info.py", line 56, in convert
    raise ZConfig.DataConversionError(e, self.value, self.position)
ZConfig.DataConversionError: The directory named as part of the path /Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/instance/var/filestorage/Data.fs does not exist. (line 29, in file:///Users/sneridagh/Development/kitconcept/kitconcept.intranet/backend/instance/etc/zope.conf)
make: *** [Makefile:94: create-site] Error 1`
```