### PR TITLE
Implement kitconcept.solr support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,10 @@ build-images:  ## Build docker images
 stack-start:  ## Local Stack: Start Services
 	@echo "Start local Docker stack"
 	VOLTO_VERSION=$(VOLTO_VERSION) KC_VERSION=$(KC_VERSION) docker compose -f $(STACK_FILE) up -d --build
-	@echo "Now visit: http://kitconcept-intranet.localhost"
+	@echo "Now visit: http://$(STACK_HOSTNAME)/ to access the site"
+	@echo "- http://$(STACK_HOSTNAME)/ to access the default site"
+	@echo "- http://admin-$(STACK_HOSTNAME)/ to create a new site"
+	@echo "- http://traefik.$(STACK_HOSTNAME)/ to access the Traefik dashboard"
 
 .PHONY: start-stack
 stack-create-site:  ## Local Stack: Create a new site

--- a/backend/news/+solr.feature
+++ b/backend/news/+solr.feature
@@ -1,0 +1,1 @@
+Implement SOLR support using kitconcept.solr. @ericof

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "kitconcept.core==1.0.0a11",
+    "kitconcept.solr==1.0.0a5",
     "plone.api",
     "plone.distribution",
     "plone.restapi",

--- a/backend/scripts/default.json
+++ b/backend/scripts/default.json
@@ -5,6 +5,7 @@
     "default_language": "en",
     "portal_timezone": "Europe/Berlin",
     "workflow": "public",
+    "setup_solr": false,
     "setup_content": true,
     "authentication": {"provider": "internal"},
     "distribution": "kitconcept-intranet"

--- a/backend/src/kitconcept/intranet/dependencies.zcml
+++ b/backend/src/kitconcept/intranet/dependencies.zcml
@@ -9,6 +9,6 @@
   <include package="pas.plugins.authomatic" />
   <include package="pas.plugins.keycloakgroups" />
   <include package="pas.plugins.oidc" />
-  <!-- <include package="kitconcept.solr" /> -->
+  <include package="kitconcept.solr" />
 
 </configure>

--- a/backend/src/kitconcept/intranet/distributions/intranet/schema.json
+++ b/backend/src/kitconcept/intranet/distributions/intranet/schema.json
@@ -194,6 +194,12 @@
         "default": "public"
       },
       "default_language": {"$ref": "#/definitions/languages"},
+      "setup_solr": {
+        "type": "boolean",
+        "title": "Use SOLR",
+        "description": "Should we use SOLR for search?",
+        "default": false
+      },
       "setup_content": {
         "type": "boolean",
         "title": "Create Example Content",

--- a/backend/src/kitconcept/intranet/handlers.py
+++ b/backend/src/kitconcept/intranet/handlers.py
@@ -55,11 +55,12 @@ def pre_handler(answers: dict) -> dict:
 def handler(distribution: Distribution, site: PloneSite, answers: dict) -> PloneSite:
     """Handler to create a new site."""
     default_profiles = distribution._profiles
-    workflow = answers.get("workflow", "restricted")
-    if workflow == "restricted":
-        profiles = deepcopy(default_profiles)
+    profiles = deepcopy(default_profiles)
+    if answers.get("workflow", "restricted") == "restricted":
         profiles["base"].append("kitconcept.intranet:restricted")
-        distribution._profiles = profiles
+    if answers.get("setup_solr", False):
+        profiles["base"].append("kitconcept.intranet:solr")
+    distribution._profiles = profiles
     site = default_handler(distribution, site, answers)
     distribution._profiles = default_profiles
     return site

--- a/backend/src/kitconcept/intranet/profiles.zcml
+++ b/backend/src/kitconcept/intranet/profiles.zcml
@@ -20,6 +20,13 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       directory="profiles/restricted"
       />
+  <genericsetup:registerProfile
+      name="solr"
+      title="kitconcept.intranet: Solr Support"
+      description="Setup the intranet to use Solr."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="profiles/solr"
+      />
 
   <include package=".upgrades" />
 

--- a/backend/src/kitconcept/intranet/profiles/solr/metadata.xml
+++ b/backend/src/kitconcept/intranet/profiles/solr/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+  <version>1001</version>
+  <dependencies>
+    <dependency>kitconcept.solr:default</dependency>
+  </dependencies>
+</metadata>

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -787,6 +787,40 @@ wheels = [
 ]
 
 [[package]]
+name = "collective-solr"
+version = "9.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "acquisition" },
+    { name = "datetime" },
+    { name = "lxml" },
+    { name = "plone-api" },
+    { name = "plone-app-content" },
+    { name = "plone-app-layout" },
+    { name = "plone-app-registry" },
+    { name = "plone-app-vocabularies" },
+    { name = "plone-browserlayer" },
+    { name = "plone-indexer" },
+    { name = "plone-restapi" },
+    { name = "products-cmfcore" },
+    { name = "products-cmfplone" },
+    { name = "products-genericsetup" },
+    { name = "products-zcatalog" },
+    { name = "requests-toolbelt" },
+    { name = "setuptools" },
+    { name = "transaction" },
+    { name = "zope-component" },
+    { name = "zope-i18nmessageid" },
+    { name = "zope-interface" },
+    { name = "zope-publisher" },
+    { name = "zope-schema" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/0f/f3ae94b0159c7c654065bafaaaef8a49c9f12b9ddb9d737a41b1bd785a45/collective_solr-9.4.0.tar.gz", hash = "sha256:b598f0dd58a83ac61bd5a180b48e02d3d0d5ad320f72ea92dadc5e26fafd19a2", size = 360856 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/74/6da27cbd95a0a37e10cc6059f3dd1ca27b16a02acb4fb5711be0dd022d3e/collective.solr-9.4.0-py3-none-any.whl", hash = "sha256:26edf7df61fc16cdef029bad9aeb138b645ea7cd2bf3d85d1c1c1ea2e34f116a", size = 368629 },
+]
+
+[[package]]
 name = "collective-volto-formsupport"
 version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1307,6 +1341,7 @@ name = "kitconcept-intranet"
 source = { editable = "." }
 dependencies = [
     { name = "kitconcept-core" },
+    { name = "kitconcept-solr" },
     { name = "pas-plugins-authomatic" },
     { name = "pas-plugins-keycloakgroups" },
     { name = "pas-plugins-oidc" },
@@ -1342,6 +1377,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "kitconcept-core", specifier = "==1.0.0a11" },
+    { name = "kitconcept-solr", specifier = "==1.0.0a5" },
     { name = "pas-plugins-authomatic", specifier = "==2.0.0" },
     { name = "pas-plugins-keycloakgroups", specifier = "==1.0.0b1" },
     { name = "pas-plugins-oidc", specifier = "==2.0.0" },
@@ -1372,6 +1408,22 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-docker", specifier = ">=3.2.0" },
     { name = "pytest-plone", specifier = ">=1.0.0a1" },
+]
+
+[[package]]
+name = "kitconcept-solr"
+version = "1.0.0a5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "collective-solr" },
+    { name = "plone" },
+    { name = "plone-api" },
+    { name = "plone-restapi" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/de/c2c45e52ca6d60237b01e99f47f2cebc953058ebb30a3cf0e6df929d2bc2/kitconcept.solr-1.0.0a5.tar.gz", hash = "sha256:6ec0a3491501001930631a14aeb23f53d850a8295a82e01078ca53e641f9da53", size = 84144 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/48/5e62c48eac90b7f7b39e0f058d6c4420c3dcb51f1dce397a23c713e6ae55/kitconcept.solr-1.0.0a5-py3-none-any.whl", hash = "sha256:77d6639178a459ce5602550c3464aba2ef3c12edf6b5641f4d11c445a22646a5", size = 34001 },
 ]
 
 [[package]]

--- a/docker-compose-solr.yml
+++ b/docker-compose-solr.yml
@@ -1,8 +1,7 @@
 ---
-name: kitconcept-intranet
+name: kitconcept-intranet-solr
 
 services:
-
   traefik:
     image: traefik:v2.11
 
@@ -34,12 +33,8 @@ services:
       - --api
 
   frontend:
-    build:
-      context: ./frontend
-      args:
-        - VOLTO_VERSION=${VOLTO_VERSION}
-      platforms:
-        - linux/amd64
+    image: ghcr.io/kitconcept/kitconcept-intranet-frontend:${RELEASE:-1.0.0b5}
+    platform: linux/amd64
     environment:
       RAZZLE_INTERNAL_API_PATH: http://backend:8080/Plone
     depends_on:
@@ -57,20 +52,15 @@ services:
       - traefik.http.routers.rt-frontend.middlewares=gzip
 
   backend:
-    build:
-      context: ./backend
-      args:
-        - KC_VERSION=${KC_VERSION}
-      platforms:
-        - linux/amd64
+    image: ghcr.io/kitconcept/kitconcept-intranet-backend:${RELEASE:-1.0.0b5}
+    platform: linux/amd64
     environment:
       RELSTORAGE_DSN: "dbname='${DB_NAME:-plone}' user='${DB_NAME:-plone}' host='${DB_HOST:-db}' password='${DB_PASSWORD:-OwAaOExRfIvY}' port='${DB_PORT:-5432}'"
+      ZOPE_FORM_MEMORY_LIMIT: 250MB
+      HONEYPOT_FIELD: your_email
       SOLR_HOST: solr
       SOLR_PORT: 8983
       SOLR_BASE: /solr/plone
-    depends_on:
-      - db
-      - solr
     labels:
       - traefik.enable=true
       - traefik.constraint-label=public
@@ -102,11 +92,11 @@ services:
       - traefik.http.routers.rt-backend-classic.entrypoints=http
       - traefik.http.routers.rt-backend-classic.service=svc-backend
       - traefik.http.routers.rt-backend-classic.middlewares=gzip,mw-backend-auth,mw-backend-vhm-classic
-      ## Intranet Admin
-      - traefik.http.routers.rt-backend-zmi.rule=Host(`admin-${STACK_HOSTNAME:-kitconcept-intranet.localhost}`)
-      - traefik.http.routers.rt-backend-zmi.entrypoints=http
-      - traefik.http.routers.rt-backend-zmi.service=svc-backend
-      - traefik.http.routers.rt-backend-zmi.middlewares=gzip
+      ## admin
+      - traefik.http.routers.rt-backend-admin.rule=Host(`admin.${STACK_HOSTNAME:-kitconcept-intranet.localhost}`)
+      - traefik.http.routers.rt-backend-admin.entrypoints=http
+      - traefik.http.routers.rt-backend-admin.service=svc-backend
+      - traefik.http.routers.rt-backend-admin.middlewares=gzip,mw-backend-auth
 
   db:
     image: postgres:14

--- a/frontend/packages/volto-intranet/news/+solr.feature
+++ b/frontend/packages/volto-intranet/news/+solr.feature
@@ -1,0 +1,1 @@
+Implement SOLR support using @kitconcept/solr. @ericof

--- a/frontend/packages/volto-intranet/package.json
+++ b/frontend/packages/volto-intranet/package.json
@@ -40,10 +40,12 @@
     "release-it": "^17.7.0"
   },
   "addons": [
-    "@kitconcept/core"
+    "@kitconcept/core",
+    "@kitconcept/volto-solr"
   ],
   "dependencies": {
     "@plone/components": "workspace:*",
-    "@kitconcept/core": "1.0.0-alpha.11"
+    "@kitconcept/core": "1.0.0-alpha.11",
+    "@kitconcept/volto-solr": "1.0.0-alpha.5"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1553,6 +1553,9 @@ importers:
       '@kitconcept/core':
         specifier: 1.0.0-alpha.11
         version: 1.0.0-alpha.11(@eeacms/volto-accordion-block@10.4.6)(@kitconcept/volto-banner-block@1.0.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@kitconcept/volto-bm3-compat@1.0.0-alpha.1(classnames@2.5.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@kitconcept/volto-button-block@3.0.3(classnames@2.5.1)(react-dom@18.2.0(react@18.2.0))(react-intl@3.12.1(react@18.2.0))(react@18.2.0))(@kitconcept/volto-carousel-block@2.0.0-alpha.1(classnames@2.5.1)(embla-carousel@8.5.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@kitconcept/volto-dsgvo-banner@2.3.2)(@kitconcept/volto-heading-block@2.4.0(react@18.2.0))(@kitconcept/volto-highlight-block@4.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@kitconcept/volto-introduction-block@1.0.0)(@kitconcept/volto-logos-block@3.0.0-alpha.0(classnames@2.5.1)(react-dom@18.2.0(react@18.2.0))(react-intl@3.12.1(react@18.2.0))(react@18.2.0)(storybook@8.5.3(prettier@3.2.5)))(@kitconcept/volto-separator-block@4.1.2(react-dom@18.2.0(react@18.2.0))(react-intl@3.12.1(react@18.2.0))(react@18.2.0)(storybook@8.5.3(prettier@3.2.5)))(@kitconcept/volto-slider-block@6.3.1(@plone/volto@18.23.0(@babel/runtime@7.24.7)(@popperjs/core@2.11.8)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4))(embla-carousel@8.5.2)(react@18.2.0))(@plone/registry@2.5.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@plonegovbr/volto-social-media@2.0.0-alpha.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.5.3(prettier@3.2.5)))(classnames@2.5.1)(lodash@4.17.21)(react-dom@18.2.0(react@18.2.0))(react-intl@3.12.1(react@18.2.0))(react-redux@8.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@4.2.1))(react-router-dom@5.2.0(react@18.2.0))(react@18.2.0)(semantic-ui-react@2.1.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(storybook@8.5.3(prettier@3.2.5))
+      '@kitconcept/volto-solr':
+        specifier: 1.0.0-alpha.5
+        version: 1.0.0-alpha.5(@plone/volto@18.23.0(@babel/runtime@7.24.7)(@popperjs/core@2.11.8)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4))
       '@plone/components':
         specifier: workspace:*
         version: link:../../core/packages/components
@@ -3396,6 +3399,11 @@ packages:
     resolution: {integrity: sha512-bkn1M1Lcl8P067dAUeYeWsLw5P4ZpjbKg+7Tt3/rjx7oVg4VQX/QsRfOKojQPGeFL3ifmzk9mJoW4rCF4QGFdw==}
     peerDependencies:
       '@plone/volto': ^17.0.0-alpha.21 || ^18.0.0-alpha.0
+
+  '@kitconcept/volto-solr@1.0.0-alpha.5':
+    resolution: {integrity: sha512-LQNDGnzc/WTnMTdbwwvTuisDqozZfyQBQ5ChsVaqjS+GGr8NiBTHCnzQmCuxQxMcw/RydbR7O2hNNaYmGTyQiA==}
+    peerDependencies:
+      '@plone/volto': ^16.20.0 || ^17.0.0-alpha.4
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -19095,6 +19103,10 @@ snapshots:
     transitivePeerDependencies:
       - embla-carousel
       - react
+
+  '@kitconcept/volto-solr@1.0.0-alpha.5(@plone/volto@18.23.0(@babel/runtime@7.24.7)(@popperjs/core@2.11.8)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4))':
+    dependencies:
+      '@plone/volto': 18.23.0(@babel/runtime@7.24.7)(@popperjs/core@2.11.8)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-with-direction@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(seamless-immutable@7.1.4)
 
   '@kwsites/file-exists@1.1.1':
     dependencies:

--- a/news/+solr.feature
+++ b/news/+solr.feature
@@ -1,0 +1,1 @@
+Add docker-compose-solr to test SOLR support. @ericof

--- a/repository.toml
+++ b/repository.toml
@@ -2,7 +2,7 @@
 name = "kitconcept.intranet"
 changelog = "CHANGELOG.md"
 version = "version.txt"
-compose = "docker-compose.yml"
+compose = ["docker-compose.yml", "docker-compose-solr.yml"]
 
 [repository.towncrier]
 section = "Project"


### PR DESCRIPTION
# Steps to use the solr integration (Docker)

1. Checkout the `solr-support` branch
2. On the root, run `make stack-rm` (to remove any existing content)
3. Start the stack with `make stack-start` (Will start the stack using `docker-compose-dev.yml`)
4. After a while, visit [http://admin-kitconcept-intranet.localhost/](http://admin-kitconcept-intranet.localhost/)
5. Create a new site. Please, select the option **Setup Solr**
6. Go to the ClassicUI control panel for solr [http://kitconcept-intranet.localhost/ClassicUI/@@solr-controlpanel](http://kitconcept-intranet.localhost/ClassicUI/@@solr-controlpanel) and configure solr (Hostname must be **solr**)
7. Run reindex [http://kitconcept-intranet.localhost/ClassicUI/@@solr-maintenance/reindex](http://kitconcept-intranet.localhost/ClassicUI/@@solr-maintenance/reindex)
8. Now, visit the Volto interface and enjoy the SOLR integration
