### PR TITLE
Add GHA support for running acceptance tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,112 @@
+name: Acceptance Code Quality Workflow
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+        default: Acceptance
+      short-name:
+        required: true
+        type: string
+        default: all
+      node-version:
+        required: true
+        type: string
+
+env:
+  CYPRESS_RETRIES: 2
+
+jobs:
+  acceptance:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    name: ${{ inputs.name }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Acceptance Images
+        run: |
+          make acceptance-images-build
+
+      - name: Use Node.js ${{ inputs.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}}
+
+      - name: Enable corepack
+        run: npm i -g corepack@latest && corepack enable
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Cache Cypress Binary
+        id: cache-cypress-binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/Cypress
+          key: binary-${{ env.NODE_VERSION }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          make frontend-install
+
+      - name: Install Cypress if not in cache
+        if: steps.cache-cypress-binary.outputs.cache-hit != 'true'
+        working-directory: core/packages/volto
+        shell: bash
+        run: make cypress-install
+
+      - uses: JarvusInnovations/background-action@v1
+        name: Start Servers
+        if: ${{ inputs.a11y == false || inputs.a11y == 'false' || inputs.a11y == null }}
+        with:
+          run: |
+            make acceptance-containers-start &
+
+          wait-on: |
+            http-get://localhost:55001/plone
+            http://localhost:3000
+
+          tail: true # true = stderr,stdout
+          # This will allow you to monitor the progress live
+
+          log-output-resume: stderr
+          # Eliminates previosuly output stderr log entries from post-run output
+
+          wait-for: 10m
+
+          log-output: stderr,stdout # same as true
+
+          log-output-if: failure
+
+      - name: Run Acceptance Tests
+        shell: bash
+        run: |
+          make ci-acceptance-test
+
+      # Upload Cypress screenshots
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-screenshots-acceptance-${{ inputs.short-name }}
+          path: acceptance/cypress/screenshots
+
+      # Upload Cypress videos
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-videos-acceptance-${{ inputs.short-name }}
+          path: cypress/videos

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -115,6 +115,7 @@ jobs:
         with:
           filters: |
             acceptance:
+              - '.github/workflows/acceptance*'
               - '.github/workflows/backend*'
               - '.github/workflows/frontend*'
               - 'backend/**'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,20 @@ jobs:
       contents: read
       packages: write
 
+  acceptance:
+    uses: ./.github/workflows/acceptance.yml
+    needs:
+        - config
+    with:
+        name: "Acceptance Tests"
+        short-name: "all"
+        node-version: ${{ needs.config.outputs.node-version }}
+    if: ${{ needs.config.outputs.acceptance == 'true' }}
   backend-release:
     uses: ./.github/workflows/backend-release.yml
     needs:
         - config
+        - acceptance
         - backend
     with:
       base-tag: ${{ needs.config.outputs.base-tag }}
@@ -59,6 +69,7 @@ jobs:
     uses: ./.github/workflows/frontend-release.yml
     needs:
         - config
+        - acceptance
         - frontend
     with:
       base-tag: ${{ needs.config.outputs.base-tag }}

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,17 @@ GIT_FOLDER=$(CURRENT_DIR)/.git
 
 PROJECT_NAME=kitconcept-intranet
 STACK_FILE=docker-compose-dev.yml
+STACK_FILE_ACCEPTANCE=docker-compose-acceptance.yml
 STACK_HOSTNAME=kitconcept-intranet.localhost
 
 VOLTO_VERSION = $(shell cat frontend/mrs.developer.json | python -c "import sys, json; print(json.load(sys.stdin)['core']['tag'])")
 KC_VERSION=$(shell cat backend/version.txt)
+IMAGE_TAG=latest
+
+# Environment variables to be exported
+export VOLTO_VERSION := $(VOLTO_VERSION)
+export KC_VERSION := $(KC_VERSION)
+export DOCKER_BUILDKIT := 1
 
 # We like colors
 # From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects
@@ -137,7 +144,7 @@ build-images:  ## Build docker images
 .PHONY: stack-start
 stack-start:  ## Local Stack: Start Services
 	@echo "Start local Docker stack"
-	VOLTO_VERSION=$(VOLTO_VERSION) KC_VERSION=$(KC_VERSION) docker compose -f $(STACK_FILE) up -d --build
+	@docker compose -f $(STACK_FILE) up -d --build
 	@echo "Now visit: http://kitconcept-intranet.localhost"
 
 .PHONY: start-stack
@@ -162,7 +169,9 @@ stack-rm:  ## Local Stack: Remove Services and Volumes
 	@echo "Remove local volume data"
 	@docker volume rm $(PROJECT_NAME)_vol-site-data
 
+####################################################
 ## Acceptance
+####################################################
 .PHONY: acceptance-backend-dev-start
 acceptance-backend-dev-start: ## Build Acceptance Servers
 	@echo "Build acceptance backend"
@@ -178,7 +187,7 @@ acceptance-test: ## Start Acceptance tests in interactive mode
 	@echo "Build acceptance backend"
 	$(MAKE) -C "./frontend/" acceptance-test
 
-# a11y tests
+## A11y tests
 .PHONY: acceptance-a11y-frontend-prod-start
 acceptance-a11y-frontend-prod-start: ## Start a11y acceptance frontend in prod mode
 	$(MAKE) -C "./frontend/" acceptance-a11y-frontend-prod-start
@@ -191,46 +200,32 @@ acceptance-a11y-test: ## Start a11y Cypress in interactive mode
 ci-acceptance-a11y-test: ## Run a11y cypress tests in headless mode for CI
 	$(MAKE) -C "./frontend/" ci-acceptance-a11y-test
 
-# Build Docker images
-.PHONY: acceptance-frontend-image-build
-acceptance-frontend-image-build: ## Build Acceptance frontend server image
-	@echo "Build acceptance frontend"
-	@docker build frontend -t kitconcept/kitconcept-intranet-frontend:acceptance -f frontend/Dockerfile --build-arg VOLTO_VERSION=$(VOLTO_VERSION)
-
-.PHONY: acceptance-backend-image-build
-acceptance-backend-image-build: ## Build Acceptance backend server image
-	@echo "Build acceptance backend"
-	@docker build backend -t kitconcept/kitconcept-intranet-backend:acceptance -f backend/Dockerfile.acceptance --build-arg KC_VERSION=$(KC_VERSION)
-
+## Acceptance tests with Containers
 .PHONY: acceptance-images-build
 acceptance-images-build: ## Build Acceptance frontend/backend images
-	$(MAKE) acceptance-backend-image-build
-	$(MAKE) acceptance-frontend-image-build
-
-.PHONY: acceptance-frontend-container-start
-acceptance-frontend-container-start: ## Start Acceptance frontend container
-	@echo "Start acceptance frontend"
-	@docker run --rm -p 3000:3000 --name kitconcept-intranet-frontend-acceptance --link kitconcept-intranet-backend-acceptance:backend -e RAZZLE_API_PATH=http://localhost:55001/plone -e RAZZLE_INTERNAL_API_PATH=http://backend:55001/plone -d kitconcept/kitconcept-intranet-frontend:acceptance
-
-.PHONY: acceptance-backend-container-start
-acceptance-backend-container-start: ## Start Acceptance backend container
-	@echo "Start acceptance backend"
-	@docker run --rm -p 55001:55001 --name kitconcept-intranet-backend-acceptance -d kitconcept/kitconcept-intranet-backend:acceptance
+	@echo "Build acceptance images build"
+	@docker compose -f $(STACK_FILE_ACCEPTANCE) build
 
 .PHONY: acceptance-containers-start
 acceptance-containers-start: ## Start Acceptance containers
-	$(MAKE) acceptance-backend-container-start
-	$(MAKE) acceptance-frontend-container-start
+	@echo "Start acceptance containers"
+	@docker compose -f $(STACK_FILE_ACCEPTANCE) up -d
 
 .PHONY: acceptance-containers-stop
 acceptance-containers-stop: ## Stop Acceptance containers
 	@echo "Stop acceptance containers"
-	@docker stop kitconcept-intranet-frontend-acceptance
-	@docker stop kitconcept-intranet-backend-acceptance
+	@docker compose -f $(STACK_FILE_ACCEPTANCE) down
+
+## Acceptance tests in CI
 
 .PHONY: ci-acceptance-test
 ci-acceptance-test: ## Run Acceptance tests in ci mode
-	$(MAKE) acceptance-containers-start
-	pnpm dlx wait-on --httpTimeout 20000 http-get://localhost:55001/plone http://localhost:3000
+	@echo "Run acceptance tests"
 	$(MAKE) -C "./frontend/" ci-acceptance-test
+
+.PHONY: ci-acceptance-test-complete
+ci-acceptance-test-complete: ## Start acceptance containers, wait for them to be ready, and run tests
+	$(MAKE) acceptance-containers-start
+	pnpx wait-on --httpTimeout 20000 http-get://localhost:55001/plone http://localhost:3000
+	$(MAKE) ci-acceptance-test
 	$(MAKE) acceptance-containers-stop

--- a/backend/Dockerfile.acceptance
+++ b/backend/Dockerfile.acceptance
@@ -1,29 +1,50 @@
-# syntax=docker/dockerfile:1
-ARG KC_VERSION=6.1.0
-FROM plone/server-builder:${KC_VERSION} AS builder
+# syntax=docker/dockerfile:1.9
+ARG KC_VERSION=latest
+FROM ghcr.io/kitconcept/core-builder:${KC_VERSION} AS builder
 
-WORKDIR /app
-
-
-# Add local code
-COPY scripts/ scripts/
-COPY . src
-
-# Install local requirements and pre-compile mo files
+# Move skeleton folder
 RUN <<EOT
-    set -e
-    bin/pip install mxdev uv
-    mv src/requirements-docker.txt src/requirements.txt
-    sed -i 's/-e .\[test\]/./g' src/mx.ini
-    cd /app/src
-    ../bin/mxdev -c mx.ini
-    ../bin/uv pip install -r requirements-mxdev.txt
-    ../bin/python /compile_mo.py
-    cd /app
-    rm -Rf src/
+    mv /app /app_base
 EOT
 
-FROM plone/server-acceptance:${KC_VERSION}
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync \
+        --locked \
+        --no-dev \
+        --no-group test \
+        --group container \
+        --no-install-project
+
+COPY . /src
+WORKDIR /src
+
+# Install package
+RUN --mount=type=cache,target=/root/.cache \
+    uv sync \
+        --locked \
+        --no-dev \
+        --group test \
+        --group container \
+        --no-editable
+
+# Move skeleton files to /app
+RUN <<EOT
+    mv /app_base/* /app
+    rm -Rf /app_base
+    mv scripts/create_site.py /app/scripts/create_site.py
+    mv scripts/default.json /app/scripts/default.json
+EOT
+
+# Compile translation files
+RUN <<EOT
+    /app/bin/python /compile_mo.py
+EOT
+
+
+FROM ghcr.io/kitconcept/core-prod:${KC_VERSION:-latest}
 
 LABEL maintainer="kitconcept GmbH <info@kitconcept.com>" \
       org.label-schema.name="kitconcept.intranet-acceptance" \
@@ -32,10 +53,25 @@ LABEL maintainer="kitconcept GmbH <info@kitconcept.com>" \
 
 ENV CONFIGURE_PACKAGES="plone.restapi,plone.volto,plone.volto.cors,kitconcept.intranet"
 ENV APPLY_PROFILES="kitconcept.intranet:default"
+ENV ALLOWED_DISTRIBUTIONS=kitconcept-intranet
 
-# Copy /app from builder
-COPY --from=builder /app /app
+# Copy the pre-built `/app` directory to the runtime container
+# and change the ownership to user app and group app in one step.
+COPY --from=builder --chown=500:500 /app /app
 
 RUN <<EOT
     ln -s /data /app/var
+    chown -R 500:500 /data
 EOT
+
+# Also expose port 55001
+EXPOSE 55001
+
+ENV ZSERVER_HOST=0.0.0.0
+ENV ZSERVER_PORT=55001
+ENV LISTEN_PORT=55001
+
+# Entrypoint is robot-server
+ENTRYPOINT [ "/app/bin/robot-server" ]
+
+CMD ["kitconcept.intranet.testing.ROBOT_TESTING"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -138,6 +138,8 @@ build-image:  ## Build Docker Images
 	@docker build . --platform linux/amd64 -t $(IMAGE_NAME_PREFIX)-backend:$(IMAGE_TAG) --progress plain -f Dockerfile --build-arg KC_VERSION=$(KC_VERSION)
 	@echo "$(GREEN)==> Building $(IMAGE_NAME_PREFIX)-beispiele:$(IMAGE_TAG) $(RESET)"
 	@docker build .  --pull=false --platform linux/amd64 -t $(IMAGE_NAME_PREFIX)-beispiele:$(IMAGE_TAG) -f Dockerfile.beispiele --build-arg IMAGE_TAG=$(IMAGE_TAG) --build-arg SEED=$(SEED)
+	@echo "$(GREEN)==> Building $(IMAGE_NAME_PREFIX)-acceptance:$(IMAGE_TAG) $(RESET)"
+	@docker build .  --pull=false --platform linux/amd64 -t $(IMAGE_NAME_PREFIX)-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg IMAGE_TAG=$(IMAGE_TAG) --build-arg SEED=$(SEED)
 
 # Acceptance tests
 .PHONY: acceptance-backend-start
@@ -146,4 +148,4 @@ acceptance-backend-start: ## Start backend acceptance server
 
 .PHONY: acceptance-image-build
 acceptance-image-build:  ## Build Docker Images
-	@DOCKER_BUILDKIT=1 docker build . -t $(IMAGE_NAME_PREFIX)-backend-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg KC_VERSION=$(KC_VERSION)
+	@docker build .  --pull=false --platform linux/amd64 -t $(IMAGE_NAME_PREFIX)-acceptance:$(IMAGE_TAG) -f Dockerfile.acceptance --build-arg IMAGE_TAG=$(IMAGE_TAG) --build-arg SEED=$(SEED)

--- a/backend/news/+acceptance-image.test
+++ b/backend/news/+acceptance-image.test
@@ -1,0 +1,1 @@
+Update Dockerfile.acceptance to be used in GHA. @ericof

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -50,6 +50,7 @@ test = [
     "pytest-cov",
     "pytest-docker>=3.2.0",
     "pytest-plone>=1.0.0a1",
+    "plone.app.robotframework>=2.1.5",
 ]
 container = [
     "plone.app.upgrade",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1331,6 +1331,7 @@ container = [
 test = [
     { name = "horse-with-no-namespace" },
     { name = "mypy" },
+    { name = "plone-app-robotframework" },
     { name = "plone-app-testing" },
     { name = "plone-restapi", extra = ["test"] },
     { name = "pytest" },
@@ -1366,6 +1367,7 @@ container = [
 test = [
     { name = "horse-with-no-namespace", specifier = ">=20250408.0" },
     { name = "mypy", specifier = ">=1.15.0" },
+    { name = "plone-app-robotframework", specifier = ">=2.1.5" },
     { name = "plone-app-testing" },
     { name = "plone-restapi", extras = ["test"] },
     { name = "pytest" },

--- a/docker-compose-acceptance.yml
+++ b/docker-compose-acceptance.yml
@@ -1,0 +1,28 @@
+---
+name: kitconcept-intranet-acceptance
+
+services:
+
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        - VOLTO_VERSION=${VOLTO_VERSION}
+    platform: linux/amd64
+    environment:
+      RAZZLE_API_PATH: http://localhost:55001/plone
+      RAZZLE_INTERNAL_API_PATH: http://backend:55001/plone
+    depends_on:
+      - backend
+    ports:
+      - 3000:3000
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.acceptance
+      args:
+        - KC_VERSION=${KC_VERSION}
+    platform: linux/amd64
+    ports:
+      - 55001:55001

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -19,10 +19,6 @@ GREEN=`tput setaf 2`
 RESET=`tput sgr0`
 YELLOW=`tput setaf 3`
 
-KC_VERSION=6
-DOCKER_IMAGE=plone/server-dev:${KC_VERSION}
-DOCKER_IMAGE_ACCEPTANCE=plone/server-acceptance:${KC_VERSION}
-
 ADDON_NAME='@kitconcept/volto-intranet'
 IMAGE_NAME=ghcr.io/kitconcept/kitconcept-intranet-frontend
 IMAGE_TAG=latest
@@ -98,11 +94,6 @@ ci-test: ## Run unit tests in CI
 	VOLTOCONFIG=$(pwd)/volto.config.js pnpm --filter @plone/volto i18n
 	CI=1 RAZZLE_JEST_CONFIG=$(CURRENT_DIR)/jest-addon.config.js pnpm --filter @plone/volto test -- --passWithNoTests
 
-.PHONY: backend-docker-start
-backend-docker-start:	## Starts a Docker-based backend for development
-	@echo "$(GREEN)==> Start Docker-based Plone Backend$(RESET)"
-	docker run -it --rm --name=backend -p 8080:8080 -e SITE=Plone $(DOCKER_IMAGE)
-
 ## Storybook
 .PHONY: storybook-start
 storybook-start: ## Start Storybook server on port 6006
@@ -123,14 +114,6 @@ acceptance-frontend-dev-start: ## Start acceptance frontend in development mode
 .PHONY: acceptance-frontend-prod-start
 acceptance-frontend-prod-start: ## Start acceptance frontend in production mode
 	RAZZLE_API_PATH=http://127.0.0.1:55001/plone pnpm build && pnpm start:prod
-
-.PHONY: acceptance-backend-start
-acceptance-backend-start: ## Start backend acceptance server
-	docker run -it --rm -p 55001:55001 $(DOCKER_IMAGE_ACCEPTANCE)
-
-.PHONY: ci-acceptance-backend-start
-ci-acceptance-backend-start: ## Start backend acceptance server in headless mode for CI
-	docker run -i --rm -p 55001:55001 $(DOCKER_IMAGE_ACCEPTANCE)
 
 .PHONY: acceptance-test
 acceptance-test: ## Start Cypress in interactive mode

--- a/frontend/packages/volto-intranet/news/+makefile.internal
+++ b/frontend/packages/volto-intranet/news/+makefile.internal
@@ -1,0 +1,1 @@
+Remove Makefile targets related to running the backend as a container. @ericof

--- a/news/+acceptance.internal
+++ b/news/+acceptance.internal
@@ -1,0 +1,1 @@
+Fix acceptance tests targets in the Makefile. @ericof

--- a/news/+gha-acceptance.internal
+++ b/news/+gha-acceptance.internal
@@ -1,0 +1,1 @@
+GHA: Add acceptance tests to the workflow. @ericof


### PR DESCRIPTION
Acceptance tests support for GHA workflows.

It can be improved if we adopt the same approach as VLT — by building the container images in an earlier step and then running the tests in a matrix. However, I decided to push for a simpler solution first.