### PR TITLE
Minor changes DocumentByLine

### DIFF
--- a/frontend/packages/volto-intranet/src/slots/DocumentByLine/DocumentByLine.tsx
+++ b/frontend/packages/volto-intranet/src/slots/DocumentByLine/DocumentByLine.tsx
@@ -37,14 +37,13 @@ const DocumentByLine = ({ content, ...props }: DocumentByLineProps) => {
   const form = useSelector((state: FormData) => state.form);
 
   const isAddMode = props.location.pathname.includes('/add');
+  const creators = form.global?.creators ?? content.creators ?? [];
 
   useEffect(() => {
-    !isAddMode
-      ? fetchCreatorProfiles(form.global?.creators ?? content.creators)
-      : fetchCreatorProfiles(['user']);
+    fetchCreatorProfiles(creators);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.global?.creators, content.creators, isAddMode]);
+  }, [form.global?.creators, content.creators]);
 
   const getCreatorHomePage = async (username: string): Promise<string> => {
     try {
@@ -59,7 +58,6 @@ const DocumentByLine = ({ content, ...props }: DocumentByLineProps) => {
   const fetchCreatorProfiles = async (creators: string[]) => {
     const result = await Promise.all(
       creators.map(async (user) => {
-        if (user === 'user') return [user, ''];
         const profileUrl = await getCreatorHomePage(user);
         return [user, profileUrl || ''];
       }),
@@ -109,23 +107,24 @@ const DocumentByLine = ({ content, ...props }: DocumentByLineProps) => {
                 </React.Fragment>
               ),
             )}
+            —
           </span>
         )}
-        {formattedDates.effective && (
+        {formattedDates.effective && !isAddMode && (
           <span className="documentPublished">
             {content.review_state === 'published' ? (
               <span>
-                — {intl.formatMessage(messages.published)}
-                {formattedDates.effective}
+                {intl.formatMessage(messages.published)}
+                {formattedDates.effective},
               </span>
             ) : (
               ''
             )}
           </span>
         )}
-        {formattedDates.modified && (
+        {formattedDates.modified && !isAddMode && (
           <span className="documentModified">
-            , {intl.formatMessage(messages.modified)}
+            {intl.formatMessage(messages.modified)}
             {formattedDates.modified}
           </span>
         )}


### PR DESCRIPTION
There is an issue that seems to be maybe volto related. When I add/create an object in classic, the ownership field is automatically filled with the current user:

<img width="1718" height="841" alt="Screenshot 2025-07-22 at 2 45 54 p m" src="https://github.com/user-attachments/assets/5e21909e-3283-4347-8c58-aa4fe5c7f5e7" />

In volto it remains empty:

<img width="2052" height="1037" alt="Screenshot 2025-07-22 at 2 46 24 p m" src="https://github.com/user-attachments/assets/62017757-6e02-4ba0-8e6f-aaf8ba285d83" />

This makes it impossible to create content and assign another user as additional creator, since if I add a user in the multi-select, this will be the only user considered and the logged user will not be included as creator.

The minor changes in this PR simplify some aspects of the DocumentByLine component, but we might have to look into the creators volto bug as well.


