### PR TITLE
Move https://github.com/kitconcept/volto-light-theme/pull/614 to here

### DIFF
--- a/frontend/packages/volto-intranet/news/186.feature
+++ b/frontend/packages/volto-intranet/news/186.feature
@@ -1,0 +1,2 @@
+Move https://github.com/kitconcept/volto-light-theme/pull/614 to here.
+Added TTW ConfigInjector feature. @sneridagh

--- a/frontend/packages/volto-intranet/package.json
+++ b/frontend/packages/volto-intranet/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@plone/scripts": "^3.6.2",
     "@plone/types": "workspace:*",
+    "@types/lodash": "^4.14.201",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@testing-library/react": "^16.2.0",
@@ -54,6 +55,7 @@
     "@kitconcept/core": "workspace:*",
     "@kitconcept/volto-solr": "2.0.0-alpha.1",
     "@plone-collective/volto-authomatic": "3.0.0-alpha.4",
+    "lodash": "4.17.21",
     "volto-rss-block": "^3.0.1"
   }
 }

--- a/frontend/packages/volto-intranet/src/config/blocks.ts
+++ b/frontend/packages/volto-intranet/src/config/blocks.ts
@@ -2,6 +2,24 @@ import type { ConfigType } from '@plone/registry';
 import RssDefaultTemplate from '../components/Blocks/RSS/DefaultTemplate';
 import RssGridTemplate from '../components/Blocks/RSS/GridTemplate';
 import RssSummaryTemplate from '../components/Blocks/RSS/SummaryTemplate';
+import type { StyleDefinition } from '@plone/types';
+
+declare module '@plone/types' {
+  export interface BlocksConfigData {
+    rssBlock: BlockConfigBase;
+  }
+
+  export interface BlockConfigBase {
+    themes?: StyleDefinition[];
+    templates: {
+      [key: string]: {
+        label: string;
+        template: any;
+      };
+    };
+  }
+}
+
 export default function install(config: ConfigType) {
   config.blocks.blocksConfig.rssBlock.templates = {
     default: {

--- a/frontend/packages/volto-intranet/src/config/settings.ts
+++ b/frontend/packages/volto-intranet/src/config/settings.ts
@@ -1,4 +1,5 @@
-import { ConfigType } from '@plone/registry';
+import type { ConfigType } from '@plone/registry';
+import type { apiExpandersType } from '@plone/types';
 
 export default function install(config: ConfigType) {
   config.settings.isMultilingual = false;
@@ -9,10 +10,28 @@ export default function install(config: ConfigType) {
   config.settings.intranetHeader = true;
   config.settings.siteLabel = 'Intranet';
 
-  // Add byline expander
+  const EXPANDERS_INHERIT_BEHAVIORS = 'kitconcept.blocks.config';
+
   config.settings.apiExpanders = [
     ...config.settings.apiExpanders,
     { match: '', GET_CONTENT: ['byline', 'lcm'] },
+    {
+      match: '',
+      GET_CONTENT: ['inherit'],
+      querystring: (config, querystring) => {
+        if (querystring['expand.inherit.behaviors']) {
+          return {
+            'expand.inherit.behaviors': querystring[
+              'expand.inherit.behaviors'
+            ].concat(',', EXPANDERS_INHERIT_BEHAVIORS),
+          };
+        } else {
+          return {
+            'expand.inherit.behaviors': EXPANDERS_INHERIT_BEHAVIORS,
+          };
+        }
+      },
+    } as apiExpandersType,
   ];
 
   return config;

--- a/frontend/packages/volto-intranet/src/config/slots.ts
+++ b/frontend/packages/volto-intranet/src/config/slots.ts
@@ -1,13 +1,21 @@
-import { ConfigType } from '@plone/registry';
+import type { ConfigType } from '@plone/registry';
 import CustomCSS from '../slots/CustomCSS/CustomCSS';
 import DocumentByLine from '../slots/DocumentByLine/DocumentByLine';
+import ConfigInjector from '../slots/ConfigInjector/ConfigInjector';
 
 export default function install(config: ConfigType) {
+  config.registerSlotComponent({
+    slot: 'aboveHeader',
+    name: 'ConfigInjector',
+    component: ConfigInjector,
+  });
+
   config.registerSlotComponent({
     slot: 'aboveHeader',
     name: 'CustomCSS',
     component: CustomCSS,
   });
+
   config.registerSlotComponent({
     slot: 'belowContentTitle',
     name: 'documentByLine',

--- a/frontend/packages/volto-intranet/src/helpers/BlocksConfigMerger.test.ts
+++ b/frontend/packages/volto-intranet/src/helpers/BlocksConfigMerger.test.ts
@@ -1,0 +1,98 @@
+import { BlocksConfigMerger } from './BlocksConfigMerger';
+import { describe, it, expect } from 'vitest';
+
+const baseBlocksConfig = {
+  teaser: {
+    restricted: false,
+    variations: [
+      { id: 'variation1', label: 'Variation 1' },
+      { id: 'variation2', label: 'Variation 2' },
+      { id: 'variation3', label: 'Variation 3' },
+    ],
+    themes: [],
+  },
+  gridBlock: {
+    restricted: false,
+    variations: [
+      { id: 'variationA', label: 'Variation A' },
+      { id: 'variationB', label: 'Variation B' },
+    ],
+    themes: [],
+  },
+};
+
+const mutator = {
+  teaser: {
+    disable: true,
+    variations: ['variation1', 'variation2'],
+    themes: [
+      {
+        style: {
+          '--theme-color': '#fff',
+          '--theme-high-contrast-color': '#ecebeb',
+          '--theme-foreground-color': '#000',
+          '--theme-low-contrast-foreground-color': '#555555',
+        },
+        name: 'default',
+        label: 'Default',
+      },
+    ],
+  },
+  gridBlock: {
+    variations: ['variationB'],
+  },
+  description: {
+    disable: true,
+  },
+};
+
+describe('BlocksConfigMerger', () => {
+  it('disables the block if disable is true', () => {
+    const result = BlocksConfigMerger(baseBlocksConfig, mutator);
+    expect(result.teaser.restricted).toBe(true);
+  });
+
+  it('filters variations according to mutator', () => {
+    const result = BlocksConfigMerger(baseBlocksConfig, mutator);
+    expect(result.teaser.variations.map((v) => v.id)).toEqual([
+      'variation1',
+      'variation2',
+    ]);
+    expect(result.gridBlock.variations.map((v) => v.id)).toEqual([
+      'variationB',
+    ]);
+  });
+
+  it('assigns themes from mutator', () => {
+    const result = BlocksConfigMerger(baseBlocksConfig, mutator);
+    expect(result.teaser.themes).toEqual([
+      {
+        style: {
+          '--theme-color': '#fff',
+          '--theme-high-contrast-color': '#ecebeb',
+          '--theme-foreground-color': '#000',
+          '--theme-low-contrast-foreground-color': '#555555',
+        },
+        name: 'default',
+        label: 'Default',
+      },
+    ]);
+  });
+
+  it('does not modify blocks not present in mutator', () => {
+    const result = BlocksConfigMerger(baseBlocksConfig, mutator);
+    expect(result.teaser.variations.length).toBe(2);
+    expect(result.gridBlock.restricted).toBe(false);
+  });
+
+  it('ignores blocks in mutator that do not exist in blocksConfig', () => {
+    const result = BlocksConfigMerger(baseBlocksConfig, mutator);
+    expect(result.description).toBeUndefined();
+  });
+
+  it('does not mutate the original blocksConfig', () => {
+    const original = JSON.parse(JSON.stringify(baseBlocksConfig));
+    BlocksConfigMerger(baseBlocksConfig, mutator);
+    expect(baseBlocksConfig).toEqual(original);
+  });
+});

--- a/frontend/packages/volto-intranet/src/helpers/BlocksConfigMerger.ts
+++ b/frontend/packages/volto-intranet/src/helpers/BlocksConfigMerger.ts
@@ -1,0 +1,42 @@
+import type { BlocksConfig } from '@plone/types';
+import cloneDeep from 'lodash/cloneDeep';
+import type { MutatorDSL } from '../types';
+
+// Utility type for deep recursive Partial
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object
+    ? T[P] extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : DeepPartial<T[P]>
+    : T[P];
+};
+
+export function BlocksConfigMerger(
+  blocksConfig: DeepPartial<BlocksConfig['blocksConfig']>,
+  merger: MutatorDSL,
+): BlocksConfig['blocksConfig'] {
+  const mergedConfig = cloneDeep(blocksConfig);
+
+  Object.entries(merger).forEach(([blockId, dsl]) => {
+    if (!mergedConfig[blockId]) return;
+
+    // 1. Disable block
+    if (dsl.disable) {
+      mergedConfig[blockId]!.restricted = true;
+    }
+
+    // 2. Filter variations
+    if (Array.isArray(dsl.variations) && mergedConfig[blockId]!.variations) {
+      mergedConfig[blockId]!.variations = mergedConfig[
+        blockId
+      ]!.variations!.filter((v) => dsl.variations!.includes(v.id));
+    }
+
+    // 3. Assign themes
+    if (Array.isArray(dsl.themes)) {
+      mergedConfig[blockId]!.themes = dsl.themes;
+    }
+  });
+
+  return mergedConfig as BlocksConfig['blocksConfig'];
+}

--- a/frontend/packages/volto-intranet/src/index.ts
+++ b/frontend/packages/volto-intranet/src/index.ts
@@ -1,12 +1,19 @@
-import { ConfigType } from '@plone/registry';
+import type { ConfigType } from '@plone/registry';
 import installSettings from './config/settings';
 import installSlots from './config/slots';
 import installWidgets from './config/widgets';
 import installBlocks from './config/blocks';
+import type { CustomInheritBehavior, BlocksConfigSettings } from './types';
 
 declare module '@plone/types' {
   export interface GetSiteResponse {
     'kitconcept.intranet.custom_css': string;
+  }
+
+  export interface Expanders {
+    inherit: {
+      'kitconcept.blocks.config': CustomInheritBehavior<BlocksConfigSettings>;
+    };
   }
 }
 

--- a/frontend/packages/volto-intranet/src/slots/ConfigInjector/ConfigInjector.tsx
+++ b/frontend/packages/volto-intranet/src/slots/ConfigInjector/ConfigInjector.tsx
@@ -1,0 +1,32 @@
+import config from '@plone/volto/registry';
+import { useSelector } from 'react-redux';
+import { BlocksConfigMerger } from '../../helpers/BlocksConfigMerger';
+import type { Content } from '@plone/types';
+import type { MutatorDSL } from '../../types';
+
+type FormState = {
+  content: {
+    data: Content;
+  };
+};
+
+const ConfigInjector = () => {
+  const blockConfigData = useSelector<FormState, MutatorDSL>(
+    (state) =>
+      state.content.data?.['@components']?.inherit?.['kitconcept.blocks.config']
+        ?.data?.blocks_config_mutator,
+  );
+
+  if (blockConfigData) {
+    config.blocks.blocksConfig = BlocksConfigMerger(
+      config.blocks.blocksConfig,
+      blockConfigData,
+    );
+  }
+
+  // This component does not render anything, it just injects config from the Redux
+  // store in the global config
+  return null;
+};
+
+export default ConfigInjector;

--- a/frontend/packages/volto-intranet/src/types.d.ts
+++ b/frontend/packages/volto-intranet/src/types.d.ts
@@ -1,0 +1,22 @@
+import type { StyleDefinition } from '@plone/types';
+
+export type MutatorDSL = Record<
+  string,
+  {
+    disable?: boolean;
+    variations?: string[];
+    themes?: StyleDefinition[];
+  }
+>;
+
+export type BlocksConfigSettings = {
+  blocks_config_mutator: MutatorDSL;
+};
+
+export type CustomInheritBehavior<T> = {
+  data: T;
+  from: {
+    '@id': string;
+    title: string;
+  };
+};

--- a/frontend/packages/volto-intranet/tsconfig.json
+++ b/frontend/packages/volto-intranet/tsconfig.json
@@ -1,32 +1,30 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "commonjs",
-    "allowJs": true,
-    "skipLibCheck": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "strictPropertyInitialization": false,
-    "moduleResolution": "Node",
+    "skipLibCheck": true,
+    "target": "es2022",
+    "allowJs": true,
     "resolveJsonModule": true,
+    "moduleDetection": "force",
     "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "module": "preserve",
     "noEmit": true,
+    "lib": ["es2022", "dom", "dom.iterable"],
     "jsx": "react-jsx",
     "paths": {
-      "@plone/volto/*": ["../../core/packages/volto/src/*"]
+      "@plone/volto/*": ["../../core/packages/volto/src/*"],
+      "@kitconcept/volto-intranet/*": ["./src/*"]
     }
   },
-  "include": ["src", "src/**/*.js"],
+  "include": ["src"],
   "exclude": [
     "node_modules",
     "build",
     "public",
     "coverage",
-    "src/**/*.test.{js,jsx,ts,tsx}",
-    "src/**/*.spec.{js,jsx,ts,tsx}",
-    "src/**/*.stories.{js,jsx,ts,tsx}"
+    "**/*.test.{js,jsx,ts,tsx}",
+    "**/*.spec.{js,jsx,ts,tsx}",
+    "**/*.stories.{js,jsx,ts,tsx}"
   ]
 }

--- a/frontend/packages/volto-intranet/vitest.config.mjs
+++ b/frontend/packages/volto-intranet/vitest.config.mjs
@@ -4,10 +4,13 @@ import path from 'path';
 
 export default defineConfig({
   ...voltoVitestConfig,
-  resolve: {
-    alias: {
-      '@plone/volto': path.resolve(__dirname, '../../core/packages/volto/src'), // Add paths accordingly
-      // 'promise-file-reader': require.resolve('promise-file-reader') // Add to identify dependency from package
+  server: {
+    fs: {
+      allow: [
+        // Allow vite/vitest to access these folders
+        '..', // allow going up from frontend/
+        path.resolve(__dirname, '../../../../../core/packages/volto'),
+      ],
     },
   },
 });

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1808,6 +1808,9 @@ importers:
       '@plone/components':
         specifier: workspace:*
         version: link:../../core/packages/components
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1833,6 +1836,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.2.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@types/lodash':
+        specifier: ^4.14.201
+        version: 4.17.20
       '@types/react':
         specifier: ^18
         version: 18.3.23
@@ -1921,6 +1927,12 @@ importers:
       classnames:
         specifier: ^2.2.6
         version: 2.5.1
+      embla-carousel-autoplay:
+        specifier: ^8.0.0
+        version: 8.5.2(embla-carousel@8.5.2)
+      embla-carousel-react:
+        specifier: ^8.0.0
+        version: 8.5.2(react@18.2.0)
       lodash:
         specifier: 4.17.21
         version: 4.17.21

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1927,12 +1927,6 @@ importers:
       classnames:
         specifier: ^2.2.6
         version: 2.5.1
-      embla-carousel-autoplay:
-        specifier: ^8.0.0
-        version: 8.5.2(embla-carousel@8.5.2)
-      embla-carousel-react:
-        specifier: ^8.0.0
-        version: 8.5.2(react@18.2.0)
       lodash:
         specifier: 4.17.21
         version: 4.17.21


### PR DESCRIPTION
I didn't move the widget, to keep the widgets together. This is another decision that we will have to take in the future, when the web distribution is in. I am +1 to move them to Volto itself... we'll see.

Do not merge (yet) until a PR for removing the counterparts from VLT is merged and released.
- [ ] https://github.com/kitconcept/volto-light-theme/pull/629