### PR TITLE
Use image-widget in preview_image_link

### DIFF
--- a/frontend/mrs.developer.json
+++ b/frontend/mrs.developer.json
@@ -13,7 +13,7 @@
     "package": "@kitconcept/volto-light-theme",
     "url": "git@github.com:kitconcept/volto-light-theme.git",
     "https": "https://github.com/kitconcept/volto-light-theme.git",
-    "tag": "7.0.0a25",
+    "branch": "useimagewidgetinpreview_image_link",
     "filterBlobs": true
   },
   "kitconcept-core": {

--- a/frontend/packages/volto-intranet/src/customizations/volto/components/manage/Widgets/ImageWidget.jsx
+++ b/frontend/packages/volto-intranet/src/customizations/volto/components/manage/Widgets/ImageWidget.jsx
@@ -1,0 +1,367 @@
+import React, { useEffect, useRef } from 'react';
+import { Button, Dimmer, Loader, Message } from 'semantic-ui-react';
+import { useIntl, defineMessages } from 'react-intl';
+import { useDispatch } from 'react-redux';
+import { useLocation } from 'react-router-dom';
+import loadable from '@loadable/component';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import { toast } from 'react-toastify';
+import useLinkEditor from '@plone/volto/components/manage/AnchorPlugin/useLinkEditor';
+import withObjectBrowser from '@plone/volto/components/manage/Sidebar/ObjectBrowser';
+
+import {
+  flattenToAppURL,
+  getBaseUrl,
+  isInternalURL,
+} from '@plone/volto/helpers/Url/Url';
+import { validateFileUploadSize } from '@plone/volto/helpers/FormValidation/FormValidation';
+import { usePrevious } from '@plone/volto/helpers/Utils/usePrevious';
+import { createContent } from '@plone/volto/actions/content/content';
+import { readAsDataURL } from 'promise-file-reader';
+import FormFieldWrapper from '@plone/volto/components/manage/Widgets/FormFieldWrapper';
+import Icon from '@plone/volto/components/theme/Icon/Icon';
+import Toast from '@plone/volto/components/manage/Toast/Toast';
+
+import imageBlockSVG from '@plone/volto/components/manage/Blocks/Image/block-image.svg';
+import clearSVG from '@plone/volto/icons/clear.svg';
+import navTreeSVG from '@plone/volto/icons/nav.svg';
+import linkSVG from '@plone/volto/icons/link.svg';
+import uploadSVG from '@plone/volto/icons/upload.svg';
+
+const Dropzone = loadable(() => import('react-dropzone'));
+
+export const ImageToolbar = ({ className, data, id, onChange, selected }) => (
+  <div className="image-upload-widget-toolbar">
+    <Button.Group>
+      <Button icon basic onClick={() => onChange(id, null)}>
+        <Icon className="circled" name={clearSVG} size="24px" color="#e40166" />
+      </Button>
+    </Button.Group>
+  </div>
+);
+
+const messages = defineMessages({
+  addImage: {
+    id: 'Browse the site, drop an image, or type a URL',
+    defaultMessage: 'Browse the site, drop an image, or use a URL',
+  },
+  pickAnImage: {
+    id: 'pickAnImage',
+    defaultMessage: 'Pick an existing image',
+  },
+  uploadAnImage: {
+    id: 'uploadAnImage',
+    defaultMessage: 'Upload an image from your computer',
+  },
+  linkAnImage: {
+    id: 'linkAnImage',
+    defaultMessage: 'Enter a URL to an image',
+  },
+  uploadingImage: {
+    id: 'Uploading image',
+    defaultMessage: 'Uploading image',
+  },
+  Error: {
+    id: 'Error',
+    defaultMessage: 'Error',
+  },
+  imageUploadErrorMessage: {
+    id: 'imageUploadErrorMessage',
+    defaultMessage: 'Please upload an image instead.',
+  },
+});
+
+const UnconnectedImageInput = (props) => {
+  const {
+    id,
+    onChange,
+    onFocus,
+    openObjectBrowser,
+    value,
+    imageSize = 'teaser',
+    selected = true,
+    hideLinkPicker = false,
+    hideObjectBrowserPicker = false,
+    restrictFileUpload = false,
+    objectBrowserPickerType = 'image',
+    description,
+    placeholderLinkInput = '',
+    onSelectItem,
+  } = props;
+  const imageValue = value?.[0]?.['@id'] || value;
+
+  const intl = useIntl();
+  const linkEditor = useLinkEditor();
+  const location = useLocation();
+  const dispatch = useDispatch();
+  const contextUrl = location.pathname;
+
+  const [uploading, setUploading] = React.useState(false);
+  const [dragging, setDragging] = React.useState(false);
+
+  const imageUploadInputRef = useRef(null);
+
+  const requestId = `image-upload-${id}`;
+
+  const loaded = props.request.loaded;
+  const { content } = props;
+  const imageId = content?.['@id'];
+  const image = content?.image;
+  let loading = false;
+
+  useEffect(() => {
+    if (uploading && loading && loaded) {
+      setUploading(false);
+      onChange(id, imageId, {
+        image_field: 'image',
+        image_scales: { image: [image] },
+      });
+    }
+  }, [loading, loaded, uploading, imageId, image, id, onChange]); // Explicitly list all dependencies
+
+  loading = usePrevious(props.request?.loading);
+
+  const handleUpload = React.useCallback(
+    (eventOrFile) => {
+      if (restrictFileUpload === true) return;
+      eventOrFile.target && eventOrFile.stopPropagation();
+
+      setUploading(true);
+      const file = eventOrFile.target
+        ? eventOrFile.target.files[0]
+        : eventOrFile[0];
+      if (!validateFileUploadSize(file, intl.formatMessage)) {
+        setUploading(false);
+        return;
+      }
+      readAsDataURL(file).then((fileData) => {
+        const fields = fileData.match(/^data:(.*);(.*),(.*)$/);
+        dispatch(
+          createContent(
+            getBaseUrl(contextUrl),
+            {
+              '@type': 'Image',
+              title: file.name,
+              image: {
+                data: fields[3],
+                encoding: fields[2],
+                'content-type': fields[1],
+                filename: file.name,
+              },
+            },
+            props.block || requestId,
+          ),
+        );
+      });
+    },
+    [
+      restrictFileUpload,
+      intl.formatMessage,
+      dispatch,
+      props,
+      contextUrl,
+      requestId,
+    ],
+  );
+
+  const onDragEnter = React.useCallback(() => {
+    if (restrictFileUpload === false) setDragging(true);
+  }, [restrictFileUpload]);
+  const onDragLeave = React.useCallback(() => setDragging(false), []);
+
+  return imageValue ? (
+    <div
+      className="image-upload-widget-image"
+      onClick={onFocus}
+      onKeyDown={onFocus}
+      role="toolbar"
+    >
+      {selected && <ImageToolbar {...props} />}
+      <img
+        className={props.className}
+        src={
+          isInternalURL(imageValue?.['@id'] ?? imageValue)
+            ? `${flattenToAppURL(imageValue?.['@id'] ?? imageValue)}/@@images/image/${imageSize}`
+            : imageValue?.['@id'] || imageValue
+        }
+        alt=""
+      />
+    </div>
+  ) : (
+    <div
+      className="image-upload-widget"
+      onClick={onFocus}
+      onKeyDown={onFocus}
+      role="toolbar"
+    >
+      <Dropzone
+        noClick
+        accept="image/*"
+        onDrop={(acceptedFiles) => {
+          setDragging(false);
+          if (acceptedFiles.length > 0) {
+            handleUpload(acceptedFiles);
+          } else {
+            toast.error(
+              <Toast
+                error
+                title={intl.formatMessage(messages.Error)}
+                content={intl.formatMessage(messages.imageUploadErrorMessage)}
+              />,
+            );
+          }
+        }}
+        onDragEnter={onDragEnter}
+        onDragLeave={onDragLeave}
+        className="dropzone"
+      >
+        {({ getRootProps, getInputProps }) => (
+          <div {...getRootProps()}>
+            <Message>
+              {dragging && <Dimmer active />}
+              {uploading && (
+                <Dimmer active>
+                  <Loader indeterminate>
+                    {intl.formatMessage(messages.uploadingImage)}
+                  </Loader>
+                </Dimmer>
+              )}
+              <img src={imageBlockSVG} alt="" className="placeholder" />
+              <p>{description || intl.formatMessage(messages.addImage)}</p>
+              <div className="toolbar-wrapper">
+                <div className="toolbar-inner" ref={linkEditor.anchorNode}>
+                  {hideObjectBrowserPicker === false && (
+                    <Button.Group>
+                      <Button
+                        aria-label={intl.formatMessage(messages.pickAnImage)}
+                        icon
+                        basic
+                        onClick={(e) => {
+                          onFocus && onFocus();
+                          e.preventDefault();
+                          openObjectBrowser({
+                            mode: objectBrowserPickerType,
+                            onSelectItem: onSelectItem
+                              ? onSelectItem
+                              : (url, { title, image_field, image_scales }) => {
+                                  onChange(props.id, flattenToAppURL(url), {
+                                    title,
+                                    image_field,
+                                    image_scales,
+                                  });
+                                },
+                            currentPath: contextUrl,
+                          });
+                        }}
+                        type="button"
+                      >
+                        <Icon name={navTreeSVG} size="24px" />
+                      </Button>
+                    </Button.Group>
+                  )}
+                  {restrictFileUpload === false && (
+                    <Button.Group>
+                      <Button
+                        aria-label={intl.formatMessage(messages.uploadAnImage)}
+                        icon
+                        basic
+                        compact
+                        onClick={() => {
+                          imageUploadInputRef.current.click();
+                        }}
+                        type="button"
+                      >
+                        <Icon name={uploadSVG} size="24px" />
+                      </Button>
+                      <input
+                        {...getInputProps({
+                          type: 'file',
+                          ref: imageUploadInputRef,
+                          onChange: handleUpload,
+                          style: { display: 'none' },
+                          accept: 'image/*',
+                        })}
+                      />
+                    </Button.Group>
+                  )}
+
+                  {hideLinkPicker === false && (
+                    <Button.Group>
+                      <Button
+                        icon
+                        basic
+                        aria-label={intl.formatMessage(messages.linkAnImage)}
+                        onClick={(e) => {
+                          !props.selected && onFocus && onFocus();
+                          linkEditor.show();
+                        }}
+                        type="button"
+                      >
+                        <Icon name={linkSVG} circled size="24px" />
+                      </Button>
+                    </Button.Group>
+                  )}
+                </div>
+                {linkEditor.anchorNode && (
+                  <linkEditor.LinkEditor
+                    value={imageValue}
+                    placeholder={
+                      placeholderLinkInput ||
+                      intl.formatMessage(messages.linkAnImage)
+                    }
+                    objectBrowserPickerType={objectBrowserPickerType}
+                    onChange={(_, e) =>
+                      onChange(
+                        props.id,
+                        isInternalURL(e) ? flattenToAppURL(e) : e,
+                        {},
+                      )
+                    }
+                    id={id}
+                  />
+                )}
+              </div>
+            </Message>
+          </div>
+        )}
+      </Dropzone>
+    </div>
+  );
+};
+
+export const ImageInput = compose(
+  connect(
+    (state, ownProps) => {
+      const requestId = `image-upload-${ownProps.id}`;
+      return {
+        request: state.content.subrequests[ownProps.block || requestId] || {},
+        content: state.content.subrequests[ownProps.block || requestId]?.data,
+      };
+    },
+    { createContent },
+  ),
+)(withObjectBrowser(UnconnectedImageInput));
+
+const ImageUploadWidget = (props) => {
+  const { fieldSet, id, title } = props;
+  return (
+    <FormFieldWrapper
+      {...props}
+      columns={1}
+      className="block image-upload-widget"
+    >
+      <div className="wrapper">
+        <label
+          id={`fieldset-${fieldSet}-field-label-${id}`}
+          htmlFor={`field-${id}`}
+        >
+          {title}
+        </label>
+      </div>
+      <ImageInput {...props} />
+    </FormFieldWrapper>
+  );
+};
+
+export default ImageUploadWidget;

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2088,6 +2088,43 @@ importers:
         specifier: ^17.1.1
         version: 17.11.0(typescript@5.8.3)
 
+  packages/volto-social-media/frontend/packages/volto-social-media:
+    dependencies:
+      '@plone/components':
+        specifier: workspace:*
+        version: link:../../../../../core/packages/components
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: 18.2.0
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@plone/scripts':
+        specifier: ^3.6.2
+        version: 3.10.1
+      '@plone/types':
+        specifier: workspace:*
+        version: link:../../../../../core/packages/types
+      '@types/jest':
+        specifier: ^29.5.8
+        version: 29.5.14
+      '@types/lodash':
+        specifier: ^4.14.201
+        version: 4.17.20
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.23
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.23)
+      react-intl:
+        specifier: ^3.12.1
+        version: 3.12.1(react@18.2.0)
+      release-it:
+        specifier: ^17.7.0
+        version: 17.11.0(typescript@5.8.3)
+
 packages:
 
   '@adobe/css-tools@4.4.3':


### PR DESCRIPTION
TICKET: https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/issues/137

I saw an issue , when using external urls in preview images, it shows but on saving , it throws an error:
<img width="279" height="317" alt="image" src="https://github.com/user-attachments/assets/62a3f79f-8856-4b37-9fe3-908ac39a10c0" />

Traceback-
```

    "message": "[{'message': 'Could not resolve object for data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBwgHP4vj/ZGggAx3+SD//2Q== (resolved by UID)', 'field': 'preview_image_link', 'error': 'ValidationError'}]",
    "traceback": [
        "File \"/Users/tishasoumya/Documents/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZPublisher/WSGIPublisher.py\", line 181, in transaction_pubevents",
        "    yield",
        "",
        "  File \"/Users/tishasoumya/Documents/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZPublisher/WSGIPublisher.py\", line 390, in publish_module",
        "    response = _publish(request, new_mod_info)",
        "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
        "",
        "  File \"/Users/tishasoumya/Documents/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZPublisher/WSGIPublisher.py\", line 284, in publish",
        "    result = mapply(obj,",
        "             ^^^^^^^^^^^",
        "",
        "  File \"/Users/tishasoumya/Documents/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZPublisher/mapply.py\", line 98, in mapply",
        "    return debug(object, args, context)",
        "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
        "",
        "  File \"/Users/tishasoumya/Documents/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/ZPublisher/WSGIPublisher.py\", line 68, in call_object",
        "    return obj(*args)",
        "           ^^^^^^^^^^",
        "",
        "  File \"/Users/tishasoumya/Documents/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/plone/rest/service.py\", line 21, in __call__",
        "    return self.render()",
        "           ^^^^^^^^^^^^^",
        "",
        "  File \"/Users/tishasoumya/Documents/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/plone/restapi/services/__init__.py\", line 19, in render",
        "    content = self.reply()",
        "              ^^^^^^^^^^^^",
        "",
        "  File \"/Users/tishasoumya/Documents/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/plone/restapi/services/content/update.py\", line 32, in reply",
        "    deserializer()",
        "",
        "  File \"/Users/tishasoumya/Documents/kitconcept.intranet/backend/.venv/lib/python3.12/site-packages/plone/restapi/deserializer/dxcontent.py\", line 63, in __call__",
        "    raise BadRequest(errors)"
    ],
    "type": "BadRequest"
}
```

When I tried debugging , maybe it is looking for internal plone images (not sure) 
```
    preview_image_link = RelationChoice(
        title=_("label_previewimage", default="Preview image"),
        description=_(
            "help_previewimage",
            default="Select an image that will be used in listing and teaser blocks.",
        ),
        vocabulary=VOCAB,
        required=False,
    )
```
https://github.com/plone/plone.volto/blob/main/src/plone/volto/behaviors/preview_link.py#L46

@sneridagh 