### PR TITLE
Move org unit and location fields to Categorization fieldset

### DIFF
--- a/backend/news/139.bugfix
+++ b/backend/news/139.bugfix
@@ -1,0 +1,1 @@
+Move Location and Organisational Unit fields to Categorization fieldset. @davisagli

--- a/backend/src/kitconcept/intranet/behaviors/configure.zcml
+++ b/backend/src/kitconcept/intranet/behaviors/configure.zcml
@@ -22,20 +22,14 @@
       name="kitconcept.intranet.location"
       title="Location"
       description="Fields for Location"
-      factory=".location.LocationAdapter"
       provides=".location.ILocationBehavior"
-      for=".location.ILocationMarker"
-      marker=".location.ILocationMarker"
       />
 
   <plone:behavior
       name="kitconcept.intranet.organisational_unit"
       title="Organisational Unit"
       description="Fields for Organisational Unit"
-      factory=".organisational_unit.OrganisationalUnitAdapter"
       provides=".organisational_unit.IOrganisationalUnitBehavior"
-      for=".organisational_unit.IOrganisationalUnitMarker"
-      marker=".organisational_unit.IOrganisationalUnitMarker"
       />
 
   <plone:behavior

--- a/backend/src/kitconcept/intranet/behaviors/location.py
+++ b/backend/src/kitconcept/intranet/behaviors/location.py
@@ -1,38 +1,19 @@
 from kitconcept.intranet import _
 from plone.autoform.interfaces import IFormFieldProvider
-from z3c.relationfield.relation import RelationValue
+from plone.autoform.directives import order_after
+from plone.supermodel import model
 from z3c.relationfield.schema import RelationChoice
-from zope.interface import Interface
-from zope.interface import implementer
 from zope.interface import provider
 
 
-class ILocationMarker(Interface):
-    """Marker interface for content items that use ILocationBehavior behavior."""
-
-
 @provider(IFormFieldProvider)
-class ILocationBehavior(ILocationMarker):
+class ILocationBehavior(model.Schema):
     """Behavior: Select a Location from a vocabulary."""
 
+    model.fieldset("categorization", fields=["location_reference"])
+    order_after(location_reference="subjects")
     location_reference = RelationChoice(
         title=_("Location"),
         vocabulary="kitconcept.intranet.vocabularies.location_objects",
         required=False,
     )
-
-
-@implementer(ILocationBehavior)
-class LocationAdapter:
-    """Behavior class for location."""
-
-    def __init__(self, context):
-        self.context = context
-
-    @property
-    def location_reference(self) -> RelationValue | None:
-        return self.context.location_reference
-
-    @location_reference.setter
-    def location_reference(self, value: RelationValue | None):
-        self.context.location_reference = value

--- a/backend/src/kitconcept/intranet/behaviors/organisational_unit.py
+++ b/backend/src/kitconcept/intranet/behaviors/organisational_unit.py
@@ -1,39 +1,19 @@
 from kitconcept.intranet import _
 from plone.autoform.interfaces import IFormFieldProvider
-from z3c.relationfield.relation import RelationValue
+from plone.autoform.directives import order_after
+from plone.supermodel import model
 from z3c.relationfield.schema import RelationChoice
-from zope.interface import Interface
-from zope.interface import implementer
 from zope.interface import provider
 
 
-class IOrganisationalUnitMarker(Interface):
-    """Marker interface for content items that use IOrganisationalUnitBehavior
-    behavior."""
-
-
 @provider(IFormFieldProvider)
-class IOrganisationalUnitBehavior(IOrganisationalUnitMarker):
+class IOrganisationalUnitBehavior(model.Schema):
     """Behavior: Select a OrganisationalUnit from a vocabulary."""
 
+    model.fieldset("categorization", fields=["organisational_unit_reference"])
+    order_after(organisational_unit_reference="subjects")
     organisational_unit_reference = RelationChoice(
         title=_("Organisational Unit"),
         vocabulary="kitconcept.intranet.vocabularies.organisational_unit_objects",
         required=False,
     )
-
-
-@implementer(IOrganisationalUnitBehavior)
-class OrganisationalUnitAdapter:
-    """Behavior class for OrganisationalUnit."""
-
-    def __init__(self, context):
-        self.context = context
-
-    @property
-    def organisational_unit_reference(self) -> RelationValue | None:
-        return self.context.organisational_unit_reference
-
-    @organisational_unit_reference.setter
-    def organisational_unit_reference(self, value: RelationValue | None):
-        self.context.organisational_unit_reference = value

--- a/backend/src/kitconcept/intranet/indexers/location.py
+++ b/backend/src/kitconcept/intranet/indexers/location.py
@@ -1,12 +1,12 @@
 from Acquisition import aq_base
-from kitconcept.intranet.behaviors.location import ILocationMarker
 from plone import api
 from plone.dexterity.content import DexterityContent
+from plone.dexterity.interfaces import IDexterityContent
 from plone.indexer.decorator import indexer
 from z3c.relationfield.relation import RelationValue
 
 
-@indexer(ILocationMarker)
+@indexer(IDexterityContent)
 def location_indexer(obj: DexterityContent) -> str:
     """Indexer for location attribute from ILocation behavior."""
     base_obj = aq_base(obj)
@@ -14,7 +14,9 @@ def location_indexer(obj: DexterityContent) -> str:
         base_obj, "location_reference", None
     )
     if location_reference is None:
-        return ""
+        # Don't store a value in the index
+        raise AttributeError
+
     # A relation field
     location = location_reference.to_object
     uid = api.content.get_uuid(location)

--- a/backend/src/kitconcept/intranet/indexers/organisational_unit.py
+++ b/backend/src/kitconcept/intranet/indexers/organisational_unit.py
@@ -1,12 +1,12 @@
 from Acquisition import aq_base
-from kitconcept.intranet.behaviors.organisational_unit import IOrganisationalUnitMarker
 from plone import api
 from plone.dexterity.content import DexterityContent
+from plone.dexterity.interfaces import IDexterityContent
 from plone.indexer.decorator import indexer
 from z3c.relationfield.relation import RelationValue
 
 
-@indexer(IOrganisationalUnitMarker)
+@indexer(IDexterityContent)
 def organisational_unit_indexer(obj: DexterityContent) -> str:
     """Indexer for organisational_unit_reference attribute from
     IOrganisationalUnitBehavior behavior."""
@@ -16,7 +16,9 @@ def organisational_unit_indexer(obj: DexterityContent) -> str:
         base_obj, "organisational_unit_reference", None
     )
     if organisational_unit_reference is None:
-        return ""
+        # Don't store a value in the index
+        raise AttributeError
+
     # A relation field
     organisational_unit = organisational_unit_reference.to_object
     uid = api.content.get_uuid(organisational_unit)

--- a/frontend/cypress/tests/main/content/organisational-unit.cy.js
+++ b/frontend/cypress/tests/main/content/organisational-unit.cy.js
@@ -32,6 +32,10 @@ describe('Add Content Tests', () => {
   });
   it('As editor I can add a organisational unit to Document content type and find it in listing block', function () {
     cy.intercept('PATCH', '/**/my-page').as('save');
+    cy.intercept(
+      'GET',
+      '/**/@vocabularies/kitconcept.intranet.vocabularies.organisational_unit_objects*',
+    ).as('vocab');
     cy.createContent({
       contentType: 'Organisational Unit',
       contentId: 'institute-of-robotics-and-mechatronics-organisational-unit',
@@ -45,6 +49,7 @@ describe('Add Content Tests', () => {
     });
     cy.navigate('/my-page/edit');
     cy.wait('@schema');
+    cy.wait('@vocab');
     cy.get('#field-organisational_unit_reference').click();
     cy.get(
       '#field-organisational_unit_reference .react-select__menu .react-select__option',

--- a/frontend/packages/volto-intranet/news/139.internal
+++ b/frontend/packages/volto-intranet/news/139.internal
@@ -1,0 +1,1 @@
+Fix acceptance test stability. @davisagli


### PR DESCRIPTION
https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/issues/139

<img width="392" height="774" alt="Screenshot 2025-09-04 at 12 12 12 PM" src="https://github.com/user-attachments/assets/0d26f67c-f058-4ce9-bfaf-c7c31243cbb3" />


Also clean up the behaviors; we don't need a separate adapter when the values are stored directly on the content object.

And fix the acceptance test stability.