### PR TITLE
Make the @site endpoint public so anonymous requests get bootstrap data

### DIFF
--- a/backend/news/+fixSiteServicePermissions.bugfix
+++ b/backend/news/+fixSiteServicePermissions.bugfix
@@ -1,0 +1,1 @@
+Make the `@site` endpoint accessible to anonymous users on restricted intranets, so the frontend gets its public bootstrap data (e.g. `collective.solr.active` for Solr search detection) before login. @reebalazs

--- a/backend/src/kitconcept/intranet/overrides.zcml
+++ b/backend/src/kitconcept/intranet/overrides.zcml
@@ -2,7 +2,6 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="kitconcept.internet"
     >
 
@@ -12,19 +11,6 @@
       class=".search.QueryBuilder"
       permission="zope2.View"
       layer=".interfaces.IBrowserLayer"
-      />
-
-  <!-- @site serves public bootstrap data only and must stay reachable for
-       anonymous users even when the restricted workflow removes View from
-       the site root (e.g. so volto-solr can detect collective.solr.active
-       before login). Overrides the zope2.View registration in plone.restapi. -->
-  <plone:service
-      method="GET"
-      factory="plone.restapi.services.site.get.SiteGet"
-      for="plone.restapi.bbb.IPloneSiteRoot"
-      permission="zope.Public"
-      layer=".interfaces.IBrowserLayer"
-      name="@site"
       />
 
 </configure>

--- a/backend/src/kitconcept/intranet/overrides.zcml
+++ b/backend/src/kitconcept/intranet/overrides.zcml
@@ -2,6 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="kitconcept.internet"
     >
 
@@ -11,6 +12,19 @@
       class=".search.QueryBuilder"
       permission="zope2.View"
       layer=".interfaces.IBrowserLayer"
+      />
+
+  <!-- @site serves public bootstrap data only and must stay reachable for
+       anonymous users even when the restricted workflow removes View from
+       the site root (e.g. so volto-solr can detect collective.solr.active
+       before login). Overrides the zope2.View registration in plone.restapi. -->
+  <plone:service
+      method="GET"
+      factory="plone.restapi.services.site.get.SiteGet"
+      for="plone.restapi.bbb.IPloneSiteRoot"
+      permission="zope.Public"
+      layer=".interfaces.IBrowserLayer"
+      name="@site"
       />
 
 </configure>

--- a/backend/src/kitconcept/intranet/services/configure.zcml
+++ b/backend/src/kitconcept/intranet/services/configure.zcml
@@ -14,6 +14,20 @@
       name="@types"
       />
 
+  <!-- @site serves public bootstrap data only and must stay reachable for
+       anonymous users even when the restricted workflow removes View from
+       the site root (e.g. so volto-solr can detect collective.solr.active
+       before login). Re-registers the service from plone.restapi (which uses
+       zope2.View) on our browser layer with a public permission. -->
+  <plone:service
+      method="GET"
+      factory="plone.restapi.services.site.get.SiteGet"
+      for="plone.restapi.bbb.IPloneSiteRoot"
+      permission="zope.Public"
+      layer="kitconcept.intranet.interfaces.IBrowserLayer"
+      name="@site"
+      />
+
   <adapter
       factory=".byline.BylineExpander"
       name="byline"

--- a/backend/tests/services/site/test_site_get_restricted.py
+++ b/backend/tests/services/site/test_site_get_restricted.py
@@ -1,0 +1,39 @@
+import pytest
+
+
+@pytest.fixture(scope="class")
+def answers():
+    return {
+        "site_id": "intranet",
+        "title": "Intranet",
+        "description": "Site created with A Plone distribution for Intranets with Plone. Created by kitconcept.",  # noQA: E501
+        "workflow": "restricted",
+        "available_languages": ["en"],
+        "portal_timezone": "Europe/Berlin",
+        "setup_content": True,
+        "authentication": {"provider": "internal"},
+    }
+
+
+@pytest.fixture(scope="class")
+def portal(site):
+    yield site
+
+
+class TestSiteGetRestricted:
+    """@site serves public bootstrap data and must work for anonymous users
+    even when the restricted workflow removes View from the site root."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, api_anon_request):
+        self.api_session = api_anon_request
+
+    def test_site_get_anonymous(self):
+        response = self.api_session.get("/@site")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["plone.site_title"] == "Intranet"
+
+    def test_site_root_still_requires_authentication(self):
+        response = self.api_session.get("/")
+        assert response.status_code == 401


### PR DESCRIPTION
## Problem

Ticket: https://gitlab.kitconcept.io/kitconcept/kitconcept-intranet/-/work_items/127

On a **restricted** intranet (`workflow: restricted`), after logging in via Google the old search page shows instead of the volto-solr one.

Root cause: `@kitconcept/volto-solr` decides which search UI to render from `state.site.data['collective.solr.active']`, which Volto populates with a single SSR-time fetch of `/@site`. That fetch happens while the user is still anonymous and returns **401**, because plone.restapi registers the `@site` service with `permission="zope2.View"` and the restricted workflow grants View on the site root only to `Authenticated`. The login redirect is a client-side route transition (no SSR re-run), so `state.site.data` stays empty for the whole session.

## Fix

`@site` by design serves only public bootstrap data (site title, logo, languages, timezone, feature flags, expander keys like `collective.solr.active`), so it must be reachable anonymously — making it public has no security implication.

This PR re-registers the `@site` service on the kitconcept.intranet browser layer with `permission="zope.Public"` in `overrides.zcml`. The layer-specific registration is more specific than plone.restapi's default-layer one, so it takes precedence without `z3c.unconfigure`.

With the endpoint public, the SSR fetch succeeds before login and the Solr flag is correct from the first render — no post-login reload needed, and the Solr backend detection mechanism keeps working as designed (with or without Solr installed).

A follow-up PR to plone.restapi will fix this at the source; this override can be dropped once a fixed release is adopted.

## Test

New test creates a restricted site and asserts:
- anonymous `GET /@site` returns 200 with the expected payload (fails with 401 without the ZCML change)
- anonymous `GET /` on the site root still returns 401 — the override opens only the bootstrap endpoint, not content