### PR TITLE
Upgrade pytest-plone to version 1.1.0

### DIFF
--- a/backend/news/463.test
+++ b/backend/news/463.test
@@ -1,0 +1,1 @@
+Upgrade pytest-plone to version 1.1.0 and drop the now-redundant local test fixtures. @ericof

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -55,7 +55,7 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-docker>=3.2.0",
-    "pytest-plone>=1.0.0",
+    "pytest-plone>=1.1.0",
     "plone.app.robotframework>=2.1.5",
 ]
 container = [

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,12 +1,9 @@
 from dataclasses import dataclass
-from kitconcept.core.factory import add_site
 from kitconcept.intranet.testing import FUNCTIONAL_TESTING
 from kitconcept.intranet.testing import INTEGRATION_TESTING
 from kitconcept.intranet.testing.logo import TEST_LOGO
 from pathlib import Path
 from plone import api
-from plone.app.testing.interfaces import SITE_OWNER_NAME
-from Products.CMFPlone.Portal import PloneSite
 from pytest_plone import fixtures_factory
 from requests import exceptions as exc
 from typing import Any
@@ -100,18 +97,6 @@ def answers() -> dict:
         "setup_content": False,
         "authentication": {"provider": "internal"},
     }
-
-
-@pytest.fixture(scope="session")
-def create_site(distribution_name):
-    def func(app, answers: dict) -> PloneSite:
-        with api.env.adopt_user(SITE_OWNER_NAME):
-            if (site_id := answers.get("site_id")) and site_id in app.objectIds():
-                app.manage_delObjects([site_id])
-            site = add_site(app, distribution=distribution_name, **answers)
-        return site
-
-    return func
 
 
 def is_responsive(url):

--- a/backend/tests/content_types/test_ct_lrf.py
+++ b/backend/tests/content_types/test_ct_lrf.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from collections.abc import Generator
 from kitconcept.intranet.testing.logo import TEST_LOGO
 from plone.dexterity.fti import DexterityFTI
@@ -24,9 +23,8 @@ def answers() -> dict:
 
 
 @pytest.fixture(scope="class")
-def portal(portal_class, create_site, answers) -> Generator[PloneSite]:
-    app = aq_parent(portal_class)
-    site = create_site(app=app, answers=answers)
+def portal(app_class, create_site, answers) -> Generator[PloneSite]:
+    site = create_site(app=app_class, answers=answers)
     yield site
 
 

--- a/backend/tests/content_types/test_wiki_page.py
+++ b/backend/tests/content_types/test_wiki_page.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from collections.abc import Generator
 from plone import api
 from plone.api.exc import InvalidParameterError
@@ -10,9 +9,8 @@ import pytest
 
 
 @pytest.fixture(scope="class")
-def portal(portal_class, create_site, answers) -> Generator[PloneSite]:
-    app = aq_parent(portal_class)
-    site = create_site(app=app, answers=answers)
+def portal(app_class, create_site, answers) -> Generator[PloneSite]:
+    site = create_site(app=app_class, answers=answers)
     yield site
 
 

--- a/backend/tests/creation/conftest.py
+++ b/backend/tests/creation/conftest.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from collections.abc import Generator
 from Products.CMFPlone.Portal import PloneSite
 
@@ -6,9 +5,8 @@ import pytest
 
 
 @pytest.fixture(scope="class")
-def portal(portal_class, create_site, answers) -> Generator[PloneSite]:
-    app = aq_parent(portal_class)
-    site = create_site(app=app, answers=answers)
+def portal(app_class, create_site, answers) -> Generator[PloneSite]:
+    site = create_site(app=app_class, answers=answers)
     yield site
 
 

--- a/backend/tests/creation/solr/conftest.py
+++ b/backend/tests/creation/solr/conftest.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from collections.abc import Generator
 from Products.CMFPlone.Portal import PloneSite
 
@@ -21,7 +20,6 @@ def answers():
 
 
 @pytest.fixture(scope="class")
-def portal(portal_class, create_site, answers, solr_service) -> Generator[PloneSite]:
-    app = aq_parent(portal_class)
-    site = create_site(app=app, answers=answers)
+def portal(app_class, create_site, answers) -> Generator[PloneSite]:
+    site = create_site(app=app_class, answers=answers)
     yield site

--- a/backend/tests/registration/conftest.py
+++ b/backend/tests/registration/conftest.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from collections.abc import Generator
 from kitconcept.intranet.testing.logo import TEST_LOGO
 from Products.CMFPlone.Portal import PloneSite
@@ -24,7 +23,6 @@ def answers() -> dict:
 
 
 @pytest.fixture(scope="class")
-def portal(portal_class, create_site, answers) -> Generator[PloneSite]:
-    app = aq_parent(portal_class)
-    site = create_site(app=app, answers=answers)
+def portal(app_class, create_site, answers) -> Generator[PloneSite]:
+    site = create_site(app=app_class, answers=answers)
     yield site

--- a/backend/tests/services/search/conftest.py
+++ b/backend/tests/services/search/conftest.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from collections.abc import Generator
 from kitconcept.solr.reindex_helpers import activate_and_reindex
 from plone import api
@@ -25,10 +24,9 @@ def answers():
 
 @pytest.fixture(scope="class")
 def functional_portal(
-    functional_portal_class, create_site, answers, solr_settings
+    functional_app_class, create_site, answers, solr_settings
 ) -> Generator[PloneSite]:
-    app = aq_parent(functional_portal_class)
-    site = create_site(app=app, answers=answers)
+    site = create_site(app=functional_app_class, answers=answers)
     for key, value in solr_settings.items():
         api.portal.set_registry_record(key, value)
     activate_and_reindex(site, clear=True)

--- a/backend/tests/services/site/test_site_get_restricted.py
+++ b/backend/tests/services/site/test_site_get_restricted.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from collections.abc import Generator
 from Products.CMFPlone.Portal import PloneSite
 
@@ -21,10 +20,9 @@ def answers():
 
 @pytest.fixture(scope="class")
 def functional_portal(
-    functional_portal_class, create_site, answers
+    functional_app_class, create_site, answers
 ) -> Generator[PloneSite]:
-    app = aq_parent(functional_portal_class)
-    site = create_site(app=app, answers=answers)
+    site = create_site(app=functional_app_class, answers=answers)
     yield site
 
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1554,7 +1554,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-docker", specifier = ">=3.2.0" },
-    { name = "pytest-plone", specifier = ">=1.0.0" },
+    { name = "pytest-plone", specifier = ">=1.1.0" },
 ]
 
 [[package]]
@@ -4994,7 +4994,7 @@ wheels = [
 
 [[package]]
 name = "pytest-plone"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "plone-api" },
@@ -5002,6 +5002,8 @@ dependencies = [
     { name = "plone-base" },
     { name = "plone-browserlayer" },
     { name = "plone-dexterity" },
+    { name = "plone-distribution" },
+    { name = "plone-exportimport" },
     { name = "products-cmfplone", extra = ["test"] },
     { name = "pytest" },
     { name = "requests" },
@@ -5009,9 +5011,9 @@ dependencies = [
     { name = "zope-pytestlayer" },
     { name = "zope-schema" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/57/3b6cac92b5554e1c7f124dcb2b8cf25bc3de63668d264fee2c43ab4240ca/pytest_plone-1.0.0.tar.gz", hash = "sha256:3c60b893edc9a1dadf2a21b090b1ca389a2787dc754105ee7b6b35721361a822", size = 28120, upload-time = "2026-05-18T22:12:42.902Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/9e/51694db94e142b545835d3070d213a631d29387a62a1f5fec5a00c5c237e/pytest_plone-1.1.0.tar.gz", hash = "sha256:9f3ac2e4f975dddf9c773f176de2114467d624016250bef01f8763a2d482dcf2", size = 67794, upload-time = "2026-07-13T22:17:11.462Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/a8/01780c4ded556b57e617e88e0cd0c2eb11c6f41f0f27aec3d5b3e4c1885d/pytest_plone-1.0.0-py3-none-any.whl", hash = "sha256:51533c8df40947fcf7eae865483bae6e7ac4b94481c55724846cdd86868ef058", size = 23434, upload-time = "2026-05-18T22:12:41.303Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/c32e1cc815f32b5ecd4bc8c1329f7490f35f59bf390d6eeb2a8c27610bc4/pytest_plone-1.1.0-py3-none-any.whl", hash = "sha256:89f69669ecb45f77ae3517238922f2c8a7e6eccd14dac8acd831f52a4fb4caf0", size = 30432, upload-time = "2026-07-13T22:17:10.107Z" },
 ]
 
 [[package]]

--- a/news/463.internal
+++ b/news/463.internal
@@ -1,0 +1,1 @@
+Upgrade pytest-plone to version 1.1.0 and drop the now-redundant local test fixtures. @ericof


### PR DESCRIPTION
## Summary

Upgrades `pytest-plone` to version `1.1.0` and removes the local test fixtures that are now provided by upstream.

## Changes

- Bump `pytest-plone>=1.0.0` → `pytest-plone>=1.1.0` in `backend/pyproject.toml` (and `backend/uv.lock`)
- Drop the now-redundant local `create_site` fixture and related imports from `backend/tests/conftest.py`
- Adjust dependent test modules and per-directory `conftest.py` files to the upstream fixtures

## Issue

Refs https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/issues/463

## Local Results

x1.8 improvement:

* pytest-plone 1.0.0: 279 passed in 253.19s (0:04:13)
* pytest-plone 1.1.0: 279 passed in 143.80s (0:02:23)