### PR TITLE
Restrict Plone Site access via rolemap.xml instead of a workflow

### DIFF
--- a/backend/news/479.feature
+++ b/backend/news/479.feature
@@ -1,0 +1,1 @@
+Restrict access to the intranet through permissions declared in `rolemap.xml` instead of binding a workflow to the Plone Site content type. An upgrade step updates existing sites. @ericof

--- a/backend/src/kitconcept/intranet/profiles/default/metadata.xml
+++ b/backend/src/kitconcept/intranet/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>20260611001</version>
+  <version>20260720001</version>
   <dependencies>
     <dependency>plone.app.discussion:default</dependency>
     <dependency>profile-kitconcept.contactblock:default</dependency>

--- a/backend/src/kitconcept/intranet/profiles/restricted/metadata.xml
+++ b/backend/src/kitconcept/intranet/profiles/restricted/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+  <version>1001</version>
+</metadata>

--- a/backend/src/kitconcept/intranet/profiles/restricted/rolemap.xml
+++ b/backend/src/kitconcept/intranet/profiles/restricted/rolemap.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rolemap>
+  <permissions>
+    <permission acquire="False"
+                name="Access contents information"
+    >
+      <role name="Authenticated" />
+      <role name="Member" />
+    </permission>
+    <permission acquire="False"
+                name="Modify portal content"
+    >
+      <role name="Editor" />
+      <role name="Manager" />
+      <role name="Reviewer" />
+      <role name="Site Administrator" />
+    </permission>
+    <permission acquire="False"
+                name="View"
+    >
+      <role name="Authenticated" />
+      <role name="Member" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/backend/src/kitconcept/intranet/profiles/restricted/workflows.xml
+++ b/backend/src/kitconcept/intranet/profiles/restricted/workflows.xml
@@ -10,8 +10,6 @@
     <default>
       <bound-workflow workflow_id="simple_intranet_workflow" />
     </default>
-    <type type_id="Plone Site">
-      <bound-workflow workflow_id="simple_intranet_workflow" />
-    </type>
+    <type type_id="Plone Site" />
   </bindings>
 </object>

--- a/backend/src/kitconcept/intranet/upgrades/configure.zcml
+++ b/backend/src/kitconcept/intranet/upgrades/configure.zcml
@@ -92,5 +92,6 @@
   <include package=".v20260318001" />
   <include package=".v20260401001" />
   <include package=".v20260611001" />
+  <include package=".v20260720001" />
 
 </configure>

--- a/backend/src/kitconcept/intranet/upgrades/v20260720001/__init__.py
+++ b/backend/src/kitconcept/intranet/upgrades/v20260720001/__init__.py
@@ -1,0 +1,26 @@
+from kitconcept.intranet import logger
+from plone import api
+from Products.CMFPlone.WorkflowTool import WorkflowTool
+from Products.GenericSetup.tool import SetupTool
+
+
+PROFILE_ID = "kitconcept.intranet:restricted"
+
+
+def upgrade_plone_site_permissions(context: SetupTool):
+    """Upgrade Plone Site permissions and workflow."""
+    # Check if restricted profile is applied
+    install_date: str | None = context.getProfileImportDate(f"profile-{PROFILE_ID}")
+    if not install_date:
+        logger.info("- Restricted profile not applied, no need for an upgrade.")
+        return
+    # The restricted profile did not have a version, so we set it here
+    context.setLastVersionForProfile(PROFILE_ID, "1000")
+    # Upgrade the profile
+    logger.info("- Restricted profile applied, upgrading to version 1001.")
+    context.upgradeProfile(PROFILE_ID, dest="1001")
+    # Update security settings from the workflow tool
+    wt: WorkflowTool = api.portal.get_tool("portal_workflow")
+    logger.info("- Updating security settings in the catalog.")
+    wt.updateRoleMappings()
+    logger.info("- Upgrade complete.")

--- a/backend/src/kitconcept/intranet/upgrades/v20260720001/configure.zcml
+++ b/backend/src/kitconcept/intranet/upgrades/v20260720001/configure.zcml
@@ -1,0 +1,27 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    >
+  <!-- Restricted profile -->
+  <genericsetup:upgradeSteps
+      profile="kitconcept.intranet:restricted"
+      source="1000"
+      destination="1001"
+      >
+    <genericsetup:upgradeDepends
+        title="Update workflow and permissions"
+        import_steps="rolemap workflow"
+        />
+  </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeSteps
+      profile="kitconcept.intranet:default"
+      source="20260611001"
+      destination="20260720001"
+      >
+    <genericsetup:upgradeStep
+        title="Upgrade Plone Site permissions"
+        handler=".upgrade_plone_site_permissions"
+        />
+  </genericsetup:upgradeSteps>
+</configure>

--- a/backend/tests/creation/workflow/test_creation_restricted.py
+++ b/backend/tests/creation/workflow/test_creation_restricted.py
@@ -1,5 +1,6 @@
 from plone import api
 from plone.app.testing.interfaces import SITE_OWNER_NAME
+from Products.CMFCore.WorkflowCore import WorkflowException
 from typing import Any
 
 import pytest
@@ -52,7 +53,7 @@ class TestSiteCreation:
     @pytest.mark.parametrize(
         "path,title,portal_type,review_state",
         [
-            ("/", "Intranet", "Plone Site", "published"),
+            ("/", "Intranet", "Plone Site", None),
         ],
     )
     def test_content_created(self, path, title, portal_type, review_state):
@@ -60,11 +61,18 @@ class TestSiteCreation:
             content = api.content.get(path=path)
         assert content.title == title
         assert content.portal_type == portal_type
-        assert api.content.get_state(content) == review_state
+        if review_state is not None:
+            assert api.content.get_state(content) == review_state
+        else:
+            with pytest.raises(WorkflowException) as exc:
+                api.content.get_state(content)
+            assert "No workflow provides" in str(exc.value)
 
     @pytest.mark.parametrize(
         "path,permission,role,expected",
         [
+            ("/", "Access contents information", "Anonymous", False),
+            ("/", "Access contents information", "Authenticated", True),
             ("/", "View", "Anonymous", False),
             ("/", "View", "Authenticated", True),
         ],

--- a/backend/tests/setup/test_setup_install.py
+++ b/backend/tests/setup/test_setup_install.py
@@ -18,6 +18,11 @@ class TestSetupInstall:
 
         assert IBrowserLayer in browser_layers
 
+    def test_no_dangling_upgrade_steps(self, installer):
+        """Test that there are no dangling upgrade steps."""
+        upgrade_info = installer.upgrade_info(PACKAGE_NAME)
+        assert upgrade_info["available"] is False
+
 
 class TestRegistrySettings:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Move the intranet access restriction away from a workflow bound to the **Plone Site** content type, and instead declare the required permissions directly in the `restricted` profile's `rolemap.xml`.

## Changes

- Add `profiles/restricted/rolemap.xml` restricting `View`, `Access contents information`, and `Modify portal content` on the site root.
- Remove the `simple_intranet_workflow` binding from the `Plone Site` type in `profiles/restricted/workflows.xml`.
- Add a versioned `restricted` profile (`metadata.xml`, version `1001`) with an upgrade step that reapplies the `rolemap` and `workflow` import steps.
- Add a `default`-profile upgrade step (`v20260720001`) that, for sites with the `restricted` profile applied, upgrades the profile and refreshes role mappings via the workflow tool.
- Update tests: the Plone Site no longer has a workflow state, and the new permission expectations are asserted; add a guard against dangling upgrade steps.

## Upgrade note

Existing sites with the `restricted` profile applied are migrated automatically by the `default` upgrade step.

Refs https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/issues/479