### PR TITLE
Unify byline person into a PersonPill component

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -109,7 +109,7 @@ module.exports = {
     );
     const { AddonRegistry } = require('@plone/registry/addon-registry');
 
-    const { registry } = new AddonRegistry.init(projectRootPath);
+    const { registry } = AddonRegistry.init(projectRootPath);
 
     config = lessPlugin({ registry }).modifyWebpackConfig({
       env: { target: 'web', dev: 'dev' },

--- a/frontend/packages/kitconcept-intranet/news/+addPersonPill.feature
+++ b/frontend/packages/kitconcept-intranet/news/+addPersonPill.feature
@@ -1,0 +1,1 @@
+Add Person Pill component and storybook test @Tishasoumya-02

--- a/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.stories.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.stories.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-intl-redux';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import PersonPill from '@kitconcept/intranet/components/PersonPill/PersonPill';
+
+const mockStore = configureStore();
+
+//To demonstrate the "explicit portrait" path in Storybook.
+const personImage =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+      <rect width="64" height="64" fill="#c8d3e0"/>
+      <circle cx="32" cy="25" r="12" fill="#6b7d94"/>
+      <path d="M12 60c0-13 9-20 20-20s20 7 20 20z" fill="#6b7d94"/>
+    </svg>`,
+  );
+
+const withStore = (disableProfileLinks = false) => {
+  const store = mockStore({
+    site: {
+      data: { 'kitconcept.clickable_profile_links': disableProfileLinks },
+    },
+    intl: {
+      locale: 'en',
+      messages: {},
+    },
+  });
+  const Decorator = (Story: React.ComponentType) => (
+    <Provider store={store}>
+      <Story />
+    </Provider>
+  );
+  return Decorator;
+};
+
+const meta: Meta<typeof PersonPill> = {
+  title: 'Components/PersonPill',
+  component: PersonPill,
+  decorators: [withStore()],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Unified person representation: portrait + name, ' +
+          'optionally linked to a profile. Covers Plone users, the Person content ' +
+          'type, compact pills and normal-sized bylines/footers.',
+      },
+    },
+  },
+  argTypes: {
+    id: { control: 'text' },
+    fullname: { control: 'text' },
+    name: { control: 'text' },
+    portrait: { control: 'text' },
+    url: { control: 'text' },
+    compact: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PersonPill>;
+
+// Use case 1: Plone user — no URL → not clickable.
+export const PloneUser: Story = {
+  args: {
+    id: 'anna',
+    fullname: 'Anna Becker',
+  },
+};
+
+// Use case 2: Person content type — explicit portrait + URL linking to profile.
+export const PersonContentType: Story = {
+  args: {
+    id: 'ben',
+    fullname: 'Ben Yilmaz',
+    portrait: personImage,
+    url: '/persons/ben',
+  },
+};
+
+// Use case 3: compact pill — smaller variant for inline mentions.
+export const CompactPill: Story = {
+  args: {
+    id: 'clara',
+    fullname: 'Clara Nguyen',
+    portrait: personImage,
+    url: '/persons/clara',
+    compact: true,
+  },
+};
+
+// Use case 4: byline / footer — normal size (default).
+export const Byline: Story = {
+  args: {
+    id: 'david',
+    fullname: 'David Schmidt',
+    url: '/persons/david',
+  },
+};
+
+// Icon fallback when no portrait resolves.
+export const IconFallback: Story = {
+  args: {
+    id: 'eva',
+    fullname: 'Eva Roth',
+  },
+};
+
+// Profile links disabled site-wide → renders as plain text even with a URL.
+export const ProfileLinksDisabled: Story = {
+  decorators: [withStore(true)],
+  args: {
+    id: 'ben',
+    fullname: 'Ben Yilmaz',
+    portrait: personImage,
+    url: '/persons/ben',
+  },
+};

--- a/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.stories.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.stories.tsx
@@ -57,7 +57,7 @@ const meta: Meta<typeof PersonPill> = {
     portrait: { control: 'text' },
     url: { control: 'text' },
     compact: { control: 'boolean' },
-    background: { control: 'boolean' },
+    background: { control: 'color' },
     role: { control: 'text' },
     subheading: { control: 'text' },
   },
@@ -112,7 +112,7 @@ export const WithBackground: Story = {
     fullname: 'Frida Lang',
     portrait: personImage,
     url: '/persons/frida',
-    background: true,
+    background: '#eee',
   },
 };
 
@@ -123,7 +123,7 @@ export const CompactWithBackground: Story = {
     fullname: 'Greta Vogel',
     portrait: personImage,
     compact: true,
-    background: true,
+    background: '#eee',
   },
 };
 

--- a/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.stories.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.stories.tsx
@@ -57,6 +57,9 @@ const meta: Meta<typeof PersonPill> = {
     portrait: { control: 'text' },
     url: { control: 'text' },
     compact: { control: 'boolean' },
+    background: { control: 'boolean' },
+    role: { control: 'text' },
+    subheading: { control: 'text' },
   },
 };
 
@@ -99,6 +102,50 @@ export const Byline: Story = {
     id: 'david',
     fullname: 'David Schmidt',
     url: '/persons/david',
+  },
+};
+
+// Use case 5: shared background — portrait + name in one rounded pill.
+export const WithBackground: Story = {
+  args: {
+    id: 'frida',
+    fullname: 'Frida Lang',
+    portrait: personImage,
+    url: '/persons/frida',
+    background: true,
+  },
+};
+
+// Compact + background together.
+export const CompactWithBackground: Story = {
+  args: {
+    id: 'greta',
+    fullname: 'Greta Vogel',
+    portrait: personImage,
+    compact: true,
+    background: true,
+  },
+};
+
+// Use case 6: role label above name (author / responsible bylines).
+export const WithRole: Story = {
+  args: {
+    id: 'nils',
+    fullname: 'Nils Vogl',
+    portrait: personImage,
+    url: '/persons/nils',
+    role: 'Autor/in',
+  },
+};
+
+// Use case 7: subheading below name (comment dates, activity headers, etc.).
+export const WithSubheading: Story = {
+  args: {
+    id: 'sarah',
+    fullname: 'Dr. Sarah Köhler',
+    portrait: personImage,
+    url: '/persons/sarah',
+    subheading: 'vor 2 Std.',
   },
 };
 

--- a/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.stories.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta<typeof PersonPill> = {
     url: { control: 'text' },
     compact: { control: 'boolean' },
     background: { control: 'color' },
-    role: { control: 'text' },
+    kicker: { control: 'text' },
     subheading: { control: 'text' },
   },
 };
@@ -127,14 +127,14 @@ export const CompactWithBackground: Story = {
   },
 };
 
-// Use case 6: role label above name (author / responsible bylines).
-export const WithRole: Story = {
+// Use case 6: kicker label above name (author / responsible bylines).
+export const WithKicker: Story = {
   args: {
     id: 'nils',
     fullname: 'Nils Vogl',
     portrait: personImage,
     url: '/persons/nils',
-    role: 'Autor/in',
+    kicker: 'Autor/in',
   },
 };
 

--- a/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import cx from 'classnames';
+import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
+import Icon from '@plone/volto/components/theme/Icon/Icon';
+import { expandToBackendURL } from '@plone/volto/helpers/Url/Url';
+import personSVG from '@plone/volto/icons/user.svg';
+
+type PersonPillProps = {
+  id: string;
+  fullname?: string;
+  name?: string;
+  portrait?: string;
+  url?: string;
+  compact?: boolean;
+};
+
+type SiteState = {
+  site?: { data?: { 'kitconcept.clickable_profile_links'?: boolean } };
+};
+
+const PersonPill = ({
+  id,
+  fullname,
+  name,
+  portrait,
+  url,
+  compact = false,
+}: PersonPillProps) => {
+  const showProfileLinks = useSelector(
+    (state: SiteState) =>
+      !state.site?.data?.['kitconcept.clickable_profile_links'],
+  );
+
+  const portraitSrc =
+    portrait ?? (id ? expandToBackendURL(`@portrait/${id}`) : undefined);
+
+  const [imageFailed, setImageFailed] = useState(false);
+  const showImage = Boolean(portraitSrc) && !imageFailed;
+
+  const avatar = showImage ? (
+    <img
+      className="person-pill-portrait"
+      src={portraitSrc}
+      alt={fullname || name}
+      loading="lazy"
+      onError={() => setImageFailed(true)}
+    />
+  ) : (
+    <Icon
+      className="person-pill-avatar"
+      name={personSVG}
+      size={compact ? '22px' : '32px'}
+      style={{
+        width: compact ? '22px' : '32px',
+        height: compact ? '22px' : '32px',
+      }}
+      ariaHidden
+    />
+  );
+
+  const label = <span className="person-pill-name">{fullname || name}</span>;
+
+  const showLink = Boolean(url) && showProfileLinks;
+
+  return (
+    <span className={cx('person-pill', { 'person-pill-compact': compact })}>
+      {showLink ? (
+        <UniversalLink className="person-pill-link" href={url as string}>
+          {avatar}
+          {label}
+        </UniversalLink>
+      ) : (
+        <>
+          {avatar}
+          {label}
+        </>
+      )}
+    </span>
+  );
+};
+
+export default PersonPill;

--- a/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
@@ -15,7 +15,7 @@ type PersonPillProps = {
   url?: string;
   compact?: boolean;
   background?: string;
-  role?: string;
+  kicker?: string;
   subheading?: string;
 };
 
@@ -31,7 +31,7 @@ const PersonPill = ({
   url,
   compact = false,
   background,
-  role,
+  kicker,
   subheading,
 }: PersonPillProps) => {
   const showProfileLinks = useSelector(
@@ -67,9 +67,9 @@ const PersonPill = ({
   );
 
   const label =
-    role || subheading ? (
+    kicker || subheading ? (
       <span className="person-pill-labels">
-        {role ? <span className="person-pill-role">{role}</span> : null}
+        {kicker ? <span className="person-pill-kicker">{kicker}</span> : null}
         <span className="person-pill-name">{fullname || name}</span>
         {subheading ? (
           <span className="person-pill-subheading">{subheading}</span>
@@ -86,7 +86,7 @@ const PersonPill = ({
       className={cx('person-pill', {
         'person-pill-compact': compact,
         'person-pill-background': background,
-        'person-pill-with-role': role,
+        'person-pill-with-kicker': kicker,
         'person-pill-with-subheading': subheading,
       })}
       style={

--- a/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { CSSProperties } from 'react';
 import { useSelector } from 'react-redux';
 import cx from 'classnames';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
@@ -13,7 +14,7 @@ type PersonPillProps = {
   portrait?: string;
   url?: string;
   compact?: boolean;
-  background?: boolean;
+  background?: string;
   role?: string;
   subheading?: string;
 };
@@ -29,7 +30,7 @@ const PersonPill = ({
   portrait,
   url,
   compact = false,
-  background = false,
+  background,
   role,
   subheading,
 }: PersonPillProps) => {
@@ -88,6 +89,11 @@ const PersonPill = ({
         'person-pill-with-role': role,
         'person-pill-with-subheading': subheading,
       })}
+      style={
+        background
+          ? ({ '--person-pill-background': background } as CSSProperties)
+          : undefined
+      }
     >
       {showLink ? (
         <UniversalLink className="person-pill-link" href={url as string}>

--- a/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
@@ -13,6 +13,9 @@ type PersonPillProps = {
   portrait?: string;
   url?: string;
   compact?: boolean;
+  background?: boolean;
+  role?: string;
+  subheading?: string;
 };
 
 type SiteState = {
@@ -26,6 +29,9 @@ const PersonPill = ({
   portrait,
   url,
   compact = false,
+  background = false,
+  role,
+  subheading,
 }: PersonPillProps) => {
   const showProfileLinks = useSelector(
     (state: SiteState) =>
@@ -50,21 +56,39 @@ const PersonPill = ({
     <Icon
       className="person-pill-avatar"
       name={personSVG}
-      size={compact ? '22px' : '32px'}
+      size={compact ? '24px' : '40px'}
       style={{
-        width: compact ? '22px' : '32px',
-        height: compact ? '22px' : '32px',
+        width: compact ? '24px' : '40px',
+        height: compact ? '24px' : '40px',
       }}
       ariaHidden
     />
   );
 
-  const label = <span className="person-pill-name">{fullname || name}</span>;
+  const label =
+    role || subheading ? (
+      <span className="person-pill-labels">
+        {role ? <span className="person-pill-role">{role}</span> : null}
+        <span className="person-pill-name">{fullname || name}</span>
+        {subheading ? (
+          <span className="person-pill-subheading">{subheading}</span>
+        ) : null}
+      </span>
+    ) : (
+      <span className="person-pill-name">{fullname || name}</span>
+    );
 
   const showLink = Boolean(url) && showProfileLinks;
 
   return (
-    <span className={cx('person-pill', { 'person-pill-compact': compact })}>
+    <span
+      className={cx('person-pill', {
+        'person-pill-compact': compact,
+        'person-pill-background': background,
+        'person-pill-with-role': role,
+        'person-pill-with-subheading': subheading,
+      })}
+    >
       {showLink ? (
         <UniversalLink className="person-pill-link" href={url as string}>
           {avatar}

--- a/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/PersonPill/PersonPill.tsx
@@ -36,7 +36,7 @@ const PersonPill = ({
 }: PersonPillProps) => {
   const showProfileLinks = useSelector(
     (state: SiteState) =>
-      !state.site?.data?.['kitconcept.clickable_profile_links'],
+      state.site?.data?.['kitconcept.clickable_profile_links'],
   );
 
   const portraitSrc =

--- a/frontend/packages/kitconcept-intranet/src/index.ts
+++ b/frontend/packages/kitconcept-intranet/src/index.ts
@@ -62,5 +62,4 @@ const applyConfig = (config: ConfigType) => {
   return config;
 };
 
-
 export default applyConfig;

--- a/frontend/packages/kitconcept-intranet/src/index.ts
+++ b/frontend/packages/kitconcept-intranet/src/index.ts
@@ -62,4 +62,5 @@ const applyConfig = (config: ConfigType) => {
   return config;
 };
 
+
 export default applyConfig;

--- a/frontend/packages/kitconcept-intranet/src/slots/DocumentByLine/DocumentByLine.tsx
+++ b/frontend/packages/kitconcept-intranet/src/slots/DocumentByLine/DocumentByLine.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
 import type { Content } from '@plone/types';
 import FormattedDate from '@plone/volto/components/theme/FormattedDate/FormattedDate';
-import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
 import { useSelector } from 'react-redux';
+import PersonPill from '@kitconcept/intranet/components/PersonPill/PersonPill';
 import { defineMessages, useIntl } from 'react-intl';
 
 const messages = defineMessages({
@@ -64,9 +64,8 @@ const DocumentByLine = ({ content, ...props }: DocumentByLineProps) => {
 
     return creators.map((userid: string) => {
       const userData = usersFromExpander?.[userid];
-      // The user data may not be found if a new user was selected
-      // or if a creator was entered that is not a username.
       return {
+        id: userid,
         name: userData?.fullname || userid,
         homepage: userData?.homepage,
       };
@@ -83,15 +82,9 @@ const DocumentByLine = ({ content, ...props }: DocumentByLineProps) => {
         {creatorsWithData.length > 0 && (
           <span>
             {intl.formatMessage(messages.by)}{' '}
-            {creatorsWithData.map(({ name, homepage }, index) => (
-              <React.Fragment key={name}>
-                {homepage ? (
-                  <UniversalLink className="author-name" href={homepage}>
-                    {name}
-                  </UniversalLink>
-                ) : (
-                  <span>{name}</span>
-                )}
+            {creatorsWithData.map(({ id, name }, index) => (
+              <React.Fragment key={id}>
+                <PersonPill id={id} fullname={name} />
                 {index < creatorsWithData.length - 1 && ', '}
               </React.Fragment>
             ))}

--- a/frontend/packages/kitconcept-intranet/src/slots/DocumentByLine/DocumentByLine.tsx
+++ b/frontend/packages/kitconcept-intranet/src/slots/DocumentByLine/DocumentByLine.tsx
@@ -82,7 +82,7 @@ const DocumentByLine = ({ content, ...props }: DocumentByLineProps) => {
         {creatorsWithData.length > 0 && (
           <span>
             {intl.formatMessage(messages.by)}{' '}
-            {creatorsWithData.map(({ id, name }, index) => (
+            {creatorsWithData.map(({ id, name, homepage }, index) => (
               <React.Fragment key={id}>
                 <PersonPill id={id} fullname={name} />
                 {index < creatorsWithData.length - 1 && ', '}

--- a/frontend/packages/kitconcept-intranet/src/theme/_main.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/_main.scss
@@ -4,6 +4,7 @@
 @import 'components/contentInteractions';
 @import 'components/eventsList.scss';
 @import 'components/person';
+@import 'components/personPill.scss';
 @import 'components/listingDisclaimer';
 @import '_content.scss';
 @import 'reviewSidebar.scss';

--- a/frontend/packages/kitconcept-intranet/src/theme/components/personPill.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/components/personPill.scss
@@ -1,0 +1,61 @@
+.person-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  vertical-align: middle;
+
+  .person-pill-link {
+    display: inline-flex;
+    align-items: center;
+    color: inherit;
+    gap: 10px;
+    text-decoration: none;
+
+    .person-pill-name {
+      text-decoration: none;
+    }
+  }
+
+  .person-pill-portrait,
+  .person-pill-avatar {
+    width: 32px;
+    height: 32px;
+    box-sizing: border-box;
+    flex-shrink: 0;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .person-pill-avatar {
+    padding: 4px;
+    background: var(--accent-color, #e0e0e0);
+  }
+}
+
+.person-pill-compact {
+  gap: 6px;
+
+  .person-pill-link {
+    gap: 6px;
+  }
+
+  .person-pill-portrait,
+  .person-pill-avatar {
+    width: 22px;
+    height: 22px;
+  }
+
+  .person-pill-name {
+    font-size: 14px;
+  }
+}
+
+// Honor site aspect-ratio setting (squared 4:5 instead of circle)
+.person-squared-images .person-pill {
+  .person-pill-portrait,
+  .person-pill-avatar {
+    height: auto;
+    border-radius: 0px;
+    aspect-ratio: 4 / 5;
+  }
+}

--- a/frontend/packages/kitconcept-intranet/src/theme/components/personPill.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/components/personPill.scss
@@ -41,8 +41,8 @@
   }
 }
 
-// Stacked labels: role above name, and/or subheading below name.
-.person-pill-with-role,
+// Stacked labels: kicker above name, and/or subheading below name.
+.person-pill-with-kicker,
 .person-pill-with-subheading {
   .person-pill-labels {
     display: inline-flex;
@@ -53,17 +53,17 @@
     margin-right: 5px;
   }
 
-  .person-pill-role,
+  .person-pill-kicker,
   .person-pill-subheading {
-    color: var(--person-pill-role-color, #808080);
+    color: var(--person-pill-kicker-color, #808080);
     font-size: 14px;
     font-weight: 400;
     line-height: 18px;
   }
 }
-.person-pill-with-role {
+.person-pill-with-kicker {
   .person-pill-name {
-    color: var(--person-pill-role-color, #808080);
+    color: var(--person-pill-kicker-color, #808080);
   }
 }
 // Portrait + name share one rounded background.
@@ -77,7 +77,10 @@
   gap: 5px;
 
   .person-pill-link {
-    gap: 6px;
+    gap: 5px;
+    .person-pill-name {
+      font-weight: 500;
+    }
   }
 
   .person-pill-portrait,

--- a/frontend/packages/kitconcept-intranet/src/theme/components/personPill.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/components/personPill.scss
@@ -4,6 +4,14 @@
   gap: 10px;
   vertical-align: middle;
 
+  .person-pill-name {
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 18px;
+    text-decoration: none;
+    text-transform: capitalize;
+  }
+
   .person-pill-link {
     display: inline-flex;
     align-items: center;
@@ -12,28 +20,63 @@
     text-decoration: none;
 
     .person-pill-name {
+      font-size: 14px;
+      font-weight: 700;
+      line-height: 18px;
       text-decoration: none;
+      text-transform: capitalize;
     }
   }
 
   .person-pill-portrait,
   .person-pill-avatar {
-    width: 32px;
-    height: 32px;
+    width: 40px;
+    height: 40px;
     box-sizing: border-box;
     flex-shrink: 0;
-    border-radius: 50%;
+    border-radius: 100px;
     object-fit: cover;
   }
 
   .person-pill-avatar {
-    padding: 4px;
     background: var(--accent-color, #e0e0e0);
   }
 }
 
+// Stacked labels: role above name, and/or subheading below name.
+.person-pill-with-role,
+.person-pill-with-subheading {
+  .person-pill-labels {
+    display: inline-flex;
+    flex: 1 0 0;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    margin-right: 5px;
+  }
+
+  .person-pill-role,
+  .person-pill-subheading {
+    color: var(--person-pill-role-color, #808080);
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 18px;
+  }
+}
+.person-pill-with-role {
+  .person-pill-name {
+    color: var(--person-pill-role-color, #808080);
+  }
+}
+// Portrait + name share one rounded background.
+.person-pill-background {
+  padding-right: 12px;
+  border-radius: 100px;
+  background: var(--person-pill-background, #eee);
+}
+
 .person-pill-compact {
-  gap: 6px;
+  gap: 5px;
 
   .person-pill-link {
     gap: 6px;
@@ -41,21 +84,13 @@
 
   .person-pill-portrait,
   .person-pill-avatar {
-    width: 22px;
-    height: 22px;
+    width: 24px;
+    height: 24px;
   }
 
   .person-pill-name {
-    font-size: 14px;
-  }
-}
-
-// Honor site aspect-ratio setting (squared 4:5 instead of circle)
-.person-squared-images .person-pill {
-  .person-pill-portrait,
-  .person-pill-avatar {
-    height: auto;
-    border-radius: 0px;
-    aspect-ratio: 4 / 5;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 24px;
   }
 }

--- a/frontend/packages/kitconcept-intranet/src/theme/components/personPill.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/components/personPill.scss
@@ -8,7 +8,6 @@
     font-size: 14px;
     font-weight: 700;
     line-height: 18px;
-    text-decoration: none;
     text-transform: capitalize;
   }
 
@@ -17,13 +16,12 @@
     align-items: center;
     color: inherit;
     gap: 10px;
-    text-decoration: none;
+    text-decoration: none !important;
 
     .person-pill-name {
       font-size: 14px;
       font-weight: 700;
       line-height: 18px;
-      text-decoration: none;
       text-transform: capitalize;
     }
   }
@@ -70,7 +68,7 @@
 }
 // Portrait + name share one rounded background.
 .person-pill-background {
-  padding-right: 12px;
+  padding-right: 10px;
   border-radius: 100px;
   background: var(--person-pill-background, #eee);
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1772,74 +1772,6 @@ importers:
         specifier: ^3.2.4
         version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(@vitest/ui@3.2.6)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(less@3.13.1)(lightningcss@1.32.0)(sass@1.58.0)(terser@5.48.0)(yaml@2.9.0)
 
-  packages/volto-dsgvo-banner/packages/volto-dsgvo-banner:
-    dependencies:
-      '@datapunt/matomo-tracker-js':
-        specifier: 0.5.1
-        version: 0.5.1
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: 18.2.0
-        version: 18.2.0(react@18.2.0)
-      react-ga4:
-        specifier: ^2.1.0
-        version: 2.1.0
-    devDependencies:
-      '@plone/scripts':
-        specifier: ^3.6.1
-        version: 3.10.6
-      release-it:
-        specifier: ^17.1.1
-        version: 17.11.0(typescript@5.9.3)
-
-  packages/volto-form-block/frontend/packages/volto-form-block:
-    dependencies:
-      '@hcaptcha/react-hcaptcha':
-        specifier: ^0.3.6
-        version: 0.3.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      file-saver:
-        specifier: ^2.0.5
-        version: 2.0.5
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
-      react-google-recaptcha-v3:
-        specifier: ^1.8.0
-        version: 1.11.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-    devDependencies:
-      '@plone/scripts':
-        specifier: ^3.6.1
-        version: 3.10.6
-      '@plone/types':
-        specifier: workspace:*
-        version: link:../../../../../core/packages/types
-      '@types/lodash':
-        specifier: ^4.14.201
-        version: 4.17.24
-      '@types/react':
-        specifier: ^18.3.1
-        version: 18.3.31
-      '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.7(@types/react@18.3.31)
-      lodash:
-        specifier: 4.17.21
-        version: 4.17.21
-      release-it:
-        specifier: ^19.0.5
-        version: 19.2.4(@types/node@24.13.1)(magicast@0.3.5)
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-      vitest:
-        specifier: ^3.1.2
-        version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(@vitest/ui@3.2.6)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(less@3.13.1)(lightningcss@1.32.0)(sass@1.58.0)(terser@5.48.0)(yaml@2.9.0)
-
   packages/volto-heading-block/packages/volto-heading-block:
     dependencies:
       react:
@@ -3151,9 +3083,6 @@ packages:
 
   '@cypress/xvfb@1.2.4':
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
-
-  '@datapunt/matomo-tracker-js@0.5.1':
-    resolution: {integrity: sha512-9/MW9vt/BA5Db7tO6LqCeQKtuvBNjyq51faF3AzUmPMlYsJCnASIxcut3VqJKiribhUoey7aYbPIYuj9x4DLPA==}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -11780,9 +11709,6 @@ packages:
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
-  react-ga4@2.1.0:
-    resolution: {integrity: sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==}
-
   react-google-recaptcha-v3@1.11.0:
     resolution: {integrity: sha512-kLQqpz/77m8+trpBwzqcxNtvWZYoZ/YO6Vm2cVTHW8hs80BWUfDpC7RDwuAvpswwtSYApWfaSpIDFWAIBNIYxQ==}
     peerDependencies:
@@ -15267,8 +15193,6 @@ snapshots:
       lodash.once: 4.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@datapunt/matomo-tracker-js@0.5.1': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -25258,8 +25182,6 @@ snapshots:
   react-fast-compare@2.0.4: {}
 
   react-fast-compare@3.2.2: {}
-
-  react-ga4@2.1.0: {}
 
   react-google-recaptcha-v3@1.11.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:


### PR DESCRIPTION
1. Document By Line - compact
<img width="581" height="29" alt="Screenshot 2026-07-27 at 11 59 01 AM" src="https://github.com/user-attachments/assets/08e0387c-8a24-4541-b39e-4365ec8f2786" />


Normal:
<img width="632" height="45" alt="Screenshot 2026-07-27 at 11 29 19 AM" src="https://github.com/user-attachments/assets/e5b411ee-bf13-43af-b9db-c99c89c3b38b" />

2. Subheading
<img width="624" height="44" alt="Screenshot 2026-07-27 at 11 29 04 AM" src="https://github.com/user-attachments/assets/ba94899a-9dca-4731-b660-361e8a0d164f" />

3. Kicker/Role
<img width="811" height="51" alt="Screenshot 2026-07-27 at 11 28 48 AM" src="https://github.com/user-attachments/assets/d71b66f2-30cb-4a6b-8498-a82f95601461" />

4. Mention
<img width="611" height="34" alt="Screenshot 2026-07-27 at 11 38 42 AM" src="https://github.com/user-attachments/assets/37869b59-e132-46bf-b3e7-e3795ee220f4" />


For compact pills- the font-weight is 400.
Background-can pass color

Storybook tests added
