### PR TITLE
Use site title in workspace switcher

### DIFF
--- a/frontend/packages/kitconcept-intranet/news/429.bugfix
+++ b/frontend/packages/kitconcept-intranet/news/429.bugfix
@@ -1,0 +1,1 @@
+Use site title in workspace switcher @iRohitSingh

--- a/frontend/packages/kitconcept-intranet/src/components/NavigationTree/NavigationTreePortal.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/NavigationTree/NavigationTreePortal.tsx
@@ -27,7 +27,7 @@ function NavigationTreePortal() {
   const panelRef = useRef<HTMLDivElement>(null);
 
   const siteData = useSelector((state: any) => state.site?.data);
-  const siteTitle: string = siteData?.title ?? 'Site';
+  const siteTitle = siteData?.['plone.site_title'];
 
   useEffect(() => {
     const toolbar = document.getElementById('toolbar');


### PR DESCRIPTION
Issues Link: https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/work_items/488


Screenshot

<img width="474" height="626" alt="Screenshot 2026-" src="https://github.com/user-attachments/assets/82c1906f-9d9f-4587-9c15-735a9bc1dd32" />
