### PR TITLE
Fix search results page container width

### DIFF
--- a/frontend/packages/kitconcept-intranet/news/433.bugfix
+++ b/frontend/packages/kitconcept-intranet/news/433.bugfix
@@ -1,0 +1,1 @@
+Fix search results page container width @iRohitSingh

--- a/frontend/packages/kitconcept-intranet/src/theme/components/_search.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/components/_search.scss
@@ -1,6 +1,6 @@
-#page-search > .ui.container {
+.section-search #page-search > .ui.container {
   width: 100% !important;
-  max-width: 1440px !important;
+  max-width: var(--layout-container-width) !important;
   padding: 0 10px !important;
   margin: 0 auto !important;
 }


### PR DESCRIPTION
Issues link: https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/work_items/499

<img width="1368" height="612" alt="Scre" src="https://github.com/user-attachments/assets/133a11dd-09cc-48b4-b1d9-7a07f70db86a" />



