### PR TITLE
Add Subsite content type

### DIFF
--- a/backend/news/494.feature
+++ b/backend/news/494.feature
@@ -1,0 +1,1 @@
+Added a new `Subsite` content type, a folderish container acting as a navigation root, with its own header, footer, navigation and breadcrumbs. @ericof

--- a/backend/src/kitconcept/intranet/content/subsite.py
+++ b/backend/src/kitconcept/intranet/content/subsite.py
@@ -1,0 +1,12 @@
+from plone.dexterity.content import Container
+from plone.supermodel.model import Schema
+from zope.interface import implementer
+
+
+class ISubsite(Schema):
+    """Subsite content type interface"""
+
+
+@implementer(ISubsite)
+class Subsite(Container):
+    """Subsite content type"""

--- a/backend/src/kitconcept/intranet/profiles/default/metadata.xml
+++ b/backend/src/kitconcept/intranet/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>20260720001</version>
+  <version>20260728001</version>
   <dependencies>
     <dependency>plone.app.discussion:default</dependency>
     <dependency>profile-kitconcept.contactblock:default</dependency>

--- a/backend/src/kitconcept/intranet/profiles/default/repositorytool.xml
+++ b/backend/src/kitconcept/intranet/profiles/default/repositorytool.xml
@@ -9,5 +9,9 @@
       <policy name="at_edit_autoversion" />
       <policy name="version_on_revert" />
     </type>
+    <type name="Subsite">
+      <policy name="at_edit_autoversion" />
+      <policy name="version_on_revert" />
+    </type>
   </policymap>
 </repositorytool>

--- a/backend/src/kitconcept/intranet/profiles/default/types.xml
+++ b/backend/src/kitconcept/intranet/profiles/default/types.xml
@@ -9,4 +9,9 @@
   <object meta_type="Dexterity FTI"
           name="Organisational Unit"
   />
+
+  <object meta_type="Dexterity FTI"
+          name="Subsite"
+  />
+
 </object>

--- a/backend/src/kitconcept/intranet/profiles/default/types/Subsite.xml
+++ b/backend/src/kitconcept/intranet/profiles/default/types/Subsite.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="Subsite"
+        i18n:domain="kitconcept.intranet"
+>
+
+  <!-- Basic properties -->
+  <property name="title"
+            i18n:translate=""
+  >Subsite</property>
+  <property name="description"
+            i18n:translate=""
+  />
+
+  <property name="allow_discussion">False</property>
+  <property name="factory">Subsite</property>
+  <property name="link_target" />
+
+
+  <!-- Hierarchy control -->
+  <property name="allowed_content_types">
+    <element value="Document" />
+    <element value="File" />
+    <element value="Image" />
+    <element value="Link" />
+  </property>
+  <property name="filter_content_types">True</property>
+  <property name="global_allow">True</property>
+
+
+  <!-- Schema, class and security -->
+  <property name="add_permission">kitconcept.intranet.siteadminsonly</property>
+  <property name="klass">kitconcept.intranet.content.subsite.Subsite</property>
+  <property name="model_file" />
+  <property name="model_source" />
+  <property name="schema">kitconcept.intranet.content.subsite.ISubsite</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors"
+            purge="true"
+  >
+    <element value="plone.basic" />
+    <element value="volto.preview_image_link" />
+    <element value="volto.kicker" />
+    <element value="kitconcept.intranet.location" />
+    <element value="plone.categorization" />
+    <element value="plone.publication" />
+    <element value="plone.ownership" />
+    <element value="plone.shortname" />
+    <element value="volto.navtitle" />
+    <element value="plone.excludefromnavigation" />
+    <element value="volto.blocks" />
+    <element value="voltolighttheme.header" />
+    <element value="voltolighttheme.theme" />
+    <element value="voltolighttheme.footer" />
+    <element value="kitconcept.footer" />
+    <element value="plone.constraintypes" />
+    <element value="plone.namefromtitle" />
+    <element value="plone.versioning" />
+    <element value="plone.locking" />
+    <element value="plone.translatable" />
+    <element value="plone.navigationroot" />
+  </property>
+
+</object>

--- a/backend/src/kitconcept/intranet/upgrades/configure.zcml
+++ b/backend/src/kitconcept/intranet/upgrades/configure.zcml
@@ -93,5 +93,6 @@
   <include package=".v20260401001" />
   <include package=".v20260611001" />
   <include package=".v20260720001" />
+  <include package=".v20260728001" />
 
 </configure>

--- a/backend/src/kitconcept/intranet/upgrades/v20260728001/configure.zcml
+++ b/backend/src/kitconcept/intranet/upgrades/v20260728001/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    >
+  <genericsetup:upgradeSteps
+      profile="kitconcept.intranet:default"
+      source="20260720001"
+      destination="20260728001"
+      >
+    <genericsetup:upgradeDepends
+        title="Add Subsite content type."
+        import_steps="typeinfo repositorytool"
+        />
+  </genericsetup:upgradeSteps>
+</configure>

--- a/backend/tests/content_types/conftest.py
+++ b/backend/tests/content_types/conftest.py
@@ -1,6 +1,121 @@
+from collections.abc import Callable
+from collections.abc import Generator
+from plone import api
+from plone.dexterity.content import DexterityContent
+from typing import Any
+from zope.event import notify
+from zope.lifecycleevent import ObjectModifiedEvent
+
 import pytest
 
 
 @pytest.fixture(scope="class")
 def portal(portal_class):
     yield portal_class
+
+
+@pytest.fixture(scope="session")
+def content_factory() -> Callable[[DexterityContent, dict], DexterityContent]:
+    """Return a factory to create content inside a container.
+
+    :returns: Callable taking a container and a creation payload -- keys
+        starting with ``_`` are dropped -- and returning the new content.
+    """
+
+    def func(container: DexterityContent, payload: dict) -> DexterityContent:
+        payload = {k: v for k, v in payload.items() if not k.startswith("_")}
+        with api.env.adopt_roles(["Manager"]):
+            content = api.content.create(container=container, **payload)
+        return content
+
+    return func
+
+
+@pytest.fixture(scope="class")
+def container(portal) -> DexterityContent:
+    """Return the container used to create the content instance under test.
+
+    :param portal: Plone site.
+    :returns: Container for newly created content -- the portal, by default.
+    """
+    return portal
+
+
+@pytest.fixture(scope="class")
+def content_instance(
+    content_factory: Callable[[DexterityContent, dict], DexterityContent],
+    container: DexterityContent,
+    payload: dict,
+) -> Generator[DexterityContent]:
+    """Create a content instance for the test class and remove it afterwards.
+
+    :param content_factory: Factory returned by :func:`content_factory`.
+    :param container: Container the content is created in.
+    :param payload: Creation payload, provided by the test module.
+    :returns: Generator yielding the new content object.
+    """
+    with api.env.adopt_roles(["Manager"]):
+        content = content_factory(container, payload)
+    content_id = content.id
+    yield content
+    # Cleanup after test
+    with api.env.adopt_roles(["Manager"]):
+        if content_id in container:
+            container.manage_delObjects([content_id])
+
+
+@pytest.fixture(scope="session")
+def last_version() -> Callable[[DexterityContent], Any]:
+    """Return a helper to retrieve the latest version of a content object.
+
+    :returns: Callable taking a content object and returning its
+        ``IVersionData`` as stored in ``portal_repository``.
+    """
+
+    def func(content: DexterityContent) -> Any:
+        repo_tool = api.portal.get_tool("portal_repository")
+        with api.env.adopt_roles(["Manager"]):
+            return repo_tool.retrieve(content)
+
+    return func
+
+
+@pytest.fixture(scope="session")
+def history() -> Callable[[DexterityContent], Any]:
+    """Return a helper to retrieve the version history of a content object.
+
+    :returns: Callable taking a content object and returning its
+        ``IHistory`` as stored in ``portal_repository``.
+    """
+
+    def func(content: DexterityContent) -> Any:
+        repo_tool = api.portal.get_tool("portal_repository")
+        with api.env.adopt_roles(["Manager"]):
+            return repo_tool.getHistory(content)
+
+    return func
+
+
+@pytest.fixture
+def versionable_content_types(portal) -> list[str]:
+    """Return the portal types versioning is enabled for.
+
+    :param portal: Plone site.
+    :returns: Portal type ids registered in ``portal_repository``.
+    """
+    repo_tool = api.portal.get_tool("portal_repository")
+    return repo_tool.getVersionableContentTypes()
+
+
+@pytest.fixture
+def notify_modified(portal) -> Callable[[DexterityContent], None]:
+    """Return a helper to fire an ``ObjectModifiedEvent`` for a content object.
+
+    :param portal: Plone site.
+    :returns: Callable taking a content object and notifying it was modified.
+    """
+
+    def func(content: DexterityContent) -> None:
+        notify(ObjectModifiedEvent(content))
+
+    return func

--- a/backend/tests/content_types/test_subsite.py
+++ b/backend/tests/content_types/test_subsite.py
@@ -1,0 +1,130 @@
+from collections.abc import Generator
+from kitconcept.intranet.content.subsite import ISubsite
+from kitconcept.intranet.content.subsite import Subsite
+from plone import api
+from plone.dexterity.fti import DexterityFTI
+from Products.CMFPlone.Portal import PloneSite
+from zope.component import createObject
+
+import pytest
+
+
+@pytest.fixture(scope="class")
+def portal(app_class, create_site, answers) -> Generator[PloneSite]:
+    site = create_site(app=app_class, answers=answers)
+    yield site
+
+
+@pytest.fixture(scope="class")
+def portal_type() -> str:
+    return "Subsite"
+
+
+@pytest.fixture(scope="class")
+def payload(portal_type) -> dict:
+    return {
+        "type": portal_type,
+        "id": "my-other-subsite",
+        "title": "My Subsite",
+        "description": "Description of my subsite",
+    }
+
+
+class TestSubsite:
+    @pytest.fixture(autouse=True)
+    def _setup(self, portal, get_fti, portal_type) -> None:
+        self.portal = portal
+        self.fti: DexterityFTI = get_fti(portal_type)
+
+    @pytest.mark.parametrize(
+        "attr,expected",
+        [
+            ("title", "Subsite"),
+            ("description", ""),
+            ("allow_discussion", False),
+            ("global_allow", True),
+            ("filter_content_types", True),
+            ("add_permission", "kitconcept.intranet.siteadminsonly"),
+            (
+                "allowed_content_types",
+                (
+                    "Document",
+                    "File",
+                    "Image",
+                    "Link",
+                ),
+            ),
+        ],
+    )
+    def test_fti(self, attr: str, expected):
+        assert isinstance(self.fti, DexterityFTI)
+        assert getattr(self.fti, attr) == expected
+
+    def test_factory(self):
+        factory = self.fti.factory
+        obj = createObject(factory)
+        assert obj is not None
+        assert isinstance(obj, Subsite)
+
+    @pytest.mark.parametrize(
+        "idx,behavior",
+        enumerate((
+            "plone.basic",
+            "volto.preview_image_link",
+            "volto.kicker",
+            "kitconcept.intranet.location",
+            "plone.categorization",
+            "plone.publication",
+            "plone.ownership",
+            "plone.shortname",
+            "volto.navtitle",
+            "plone.excludefromnavigation",
+            "volto.blocks",
+            "voltolighttheme.header",
+            "voltolighttheme.theme",
+            "voltolighttheme.footer",
+            "kitconcept.footer",
+            "plone.constraintypes",
+            "plone.namefromtitle",
+            "plone.versioning",
+            "plone.locking",
+            "plone.translatable",
+            "plone.navigationroot",
+        )),
+    )
+    def test_behaviors(self, idx, behavior):
+        assert self.fti.behaviors[idx] == behavior
+
+    def test_create(self, site_owner_name, portal_type):
+        container = self.portal
+        with api.env.adopt_user(site_owner_name):
+            content = api.content.create(
+                container=container,
+                type=portal_type,
+                title="My Subsite",
+                id="my-subsite",
+            )
+
+        assert content.portal_type == portal_type
+        assert content.aq_parent == container
+        assert ISubsite.providedBy(content)
+
+    def test_versionable(self, portal_type, versionable_content_types):
+        assert portal_type in versionable_content_types
+
+    def test_create_initial_version_after_adding(self, last_version, content_instance):
+        version = last_version(content_instance)
+        assert version.comment.default == "Initial version"
+        assert version.version_id == 0
+
+    def test_create_version_on_save(
+        self, notify_modified, history, last_version, content_instance
+    ):
+        with api.env.adopt_roles(["Manager"]):
+            content_instance.title = "Subsite Redux"
+            notify_modified(content_instance)
+        history_data = history(content_instance)
+        assert len(history_data) == 2  # Initial + modified version
+        version = last_version(content_instance)
+        assert version.comment is None
+        assert version.version_id == 1


### PR DESCRIPTION
## Summary

Adds a new **Subsite** content type: a folderish container that acts as a navigation root, so it gets its own header, footer, navigation and breadcrumbs.

This unblocks the DLR pitch, where we want to show that an internal publication like *Echtzeit* can live as a self-contained subsite at https://plone-intranet.kitconcept.io/echtzeit — which today is an `Organisational Unit` and therefore *not* an `INavigationRoot`.

## Changes

- New `Subsite` content type (`kitconcept.intranet.content.subsite`) with FTI in `profiles/default/types/Subsite.xml`.
  - `plone.navigationroot` → own navigation and breadcrumbs.
  - `voltolighttheme.header`, `voltolighttheme.theme`, `voltolighttheme.footer`, `kitconcept.footer` → own header/footer/theme.
  - `add_permission` is `kitconcept.intranet.siteadminsonly`, consistent with `Location` and `Organisational Unit`.
  - `allowed_content_types` limited to `Document`, `File`, `Image`, `Link`.
- Versioning policies (`at_edit_autoversion`, `version_on_revert`) registered in `repositorytool.xml`.
- Upgrade step `v20260728001` reimporting the `typeinfo` and `repositorytool` steps, so existing sites get the type and its versioning policies.
- Tests in `backend/tests/content_types/test_subsite.py` covering the FTI, factory, behaviors, creation and versioning, plus reusable content/versioning fixtures in `backend/tests/content_types/conftest.py`.

## Refs

Refs https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/issues/494

## Test plan

- `make backend-test` (or `pytest tests/content_types/test_subsite.py` → 33 passed)
- Manually: add a `Subsite` in a site, confirm it renders its own navigation, breadcrumbs, header and footer.