### PR TITLE
Fix align WikiPage document byline to default container width

### DIFF
--- a/frontend/packages/kitconcept-intranet/news/439.bugfix
+++ b/frontend/packages/kitconcept-intranet/news/439.bugfix
@@ -1,0 +1,1 @@
+Fix align WikiPage document byline to default container width @iRohitSingh

--- a/frontend/packages/kitconcept-intranet/src/theme/slots.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/slots.scss
@@ -1,3 +1,4 @@
+.contenttype-wikipage .documentByLine,
 #page-document .blocks-group-wrapper > .documentByLine {
   @include default-container-width();
   @include adjustMarginsToContainer($default-container-width);
@@ -5,6 +6,9 @@
   .author-name {
     text-decoration: none;
   }
+}
+.contenttype-wikipage .documentByLine {
+  margin-top: 0;
 }
 
 #page-edit .q.container .documentByLine,


### PR DESCRIPTION
issues Link: https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/work_items/520

Screenshot:

<img width="1457" height="294" alt="Screenshot 2026-07" src="https://github.com/user-attachments/assets/2a64ffdb-16aa-489e-837b-a9492ee5f7e6" />
