### PR TITLE
Fix Navigation Tree Content type icon is moved to the right

### DIFF
--- a/frontend/packages/kitconcept-intranet/news/442.bugfix
+++ b/frontend/packages/kitconcept-intranet/news/442.bugfix
@@ -1,0 +1,1 @@
+Fix Navigation Tree Content type icon is moved to the right @iRohitSingh

--- a/frontend/packages/kitconcept-intranet/src/theme/navigation-tree.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/navigation-tree.scss
@@ -271,6 +271,7 @@
 
       .react-aria-TreeItem {
         overflow: hidden;
+        border-left: 3px solid transparent;
         color: #333;
         font-size: 14px;
         font-weight: 400;
@@ -282,7 +283,7 @@
         }
 
         &.is-current {
-          border-left: 3px solid #1a1a1a;
+          border-left-color: #1a1a1a;
           background: #f0f0f0;
           font-weight: 600;
 


### PR DESCRIPTION
Issues Link : https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/work_items/501 

Screencast: 


https://github.com/user-attachments/assets/f8bcbd89-8d63-412f-af7a-46b0a655a162

