### PR TITLE
AI search deployment follow-up: kitconcept.solr upgrade step + cluster reindex docs (#433)

### DIFF
--- a/backend/example_content/ai-content/README.md
+++ b/backend/example_content/ai-content/README.md
@@ -83,6 +83,36 @@ answer renders above the classic results. Without credentials the
 `@site` endpoint reports `kitconcept.solr.rag_available: false` and
 the classic search works unchanged.
 
+## Deployment (docker image / cluster)
+
+The `make` targets above are development conveniences and do not exist
+in the backend docker image. In a deployment, run the same script
+through the image entrypoint (it ships in the image under
+`/app/scripts/`):
+
+```sh
+./docker-entrypoint.sh run ./scripts/solr_activate_and_reindex.py --rag-enable --clear
+```
+
+Order matters:
+
+1. Set `KITCONCEPT_SOLR_LLM_URL` and `KITCONCEPT_SOLR_LLM_TOKEN` on the
+   backend container **before** reindexing. Chunk indexing embeds the
+   content through the LLM service; without credentials the RAG
+   processor silently skips every document — the reindex "succeeds"
+   but the AI search has nothing to answer from. (Classic search is
+   unaffected either way.)
+2. Run the site upgrade (`@@plone-upgrade` / portal_setup). The
+   kitconcept.intranet upgrade step `v20260729001` cascades the
+   kitconcept.solr profile upgrade (registry record + RAG indexing
+   queue processor) on sites that have Solr support installed.
+3. Run the command above to enable the feature and rebuild the index
+   (`--clear` drops the old index first; `--rag-disable` is the
+   rollback switch).
+
+The script targets the site id `Plone` (matching the devops stacks)
+and exits with a notice on sites created without Solr support.
+
 ## Example users
 
 All users share the password `intranet-demo-2026` (fictional accounts,

--- a/backend/news/+ai-search-deploy-docs.documentation
+++ b/backend/news/+ai-search-deploy-docs.documentation
@@ -1,0 +1,1 @@
+Document the cluster deployment of the AI search: run scripts/solr_activate_and_reindex.py through the image entrypoint, set the LLM credentials before reindexing, site upgrade cascades the kitconcept.solr profile upgrade. @reebalazs

--- a/backend/news/+ai-search-upgrade-step.feature
+++ b/backend/news/+ai-search-upgrade-step.feature
@@ -1,0 +1,1 @@
+Add upgrade step v20260729001: upgrade the kitconcept.solr profile (AI search support) on existing sites, bailing out when the add-on is not installed. @reebalazs

--- a/backend/src/kitconcept/intranet/profiles/default/metadata.xml
+++ b/backend/src/kitconcept/intranet/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>20260728001</version>
+  <version>20260729001</version>
   <dependencies>
     <dependency>plone.app.discussion:default</dependency>
     <dependency>profile-kitconcept.contactblock:default</dependency>

--- a/backend/src/kitconcept/intranet/upgrades/configure.zcml
+++ b/backend/src/kitconcept/intranet/upgrades/configure.zcml
@@ -94,5 +94,6 @@
   <include package=".v20260611001" />
   <include package=".v20260720001" />
   <include package=".v20260728001" />
+  <include package=".v20260729001" />
 
 </configure>

--- a/backend/src/kitconcept/intranet/upgrades/v20260729001/__init__.py
+++ b/backend/src/kitconcept/intranet/upgrades/v20260729001/__init__.py
@@ -1,0 +1,23 @@
+from kitconcept.intranet import logger
+from Products.GenericSetup.tool import SetupTool
+from Products.GenericSetup.tool import UNKNOWN
+
+
+SOLR_PROFILE_ID = "kitconcept.solr:default"
+
+
+def upgrade_kitconcept_solr(setup_tool: SetupTool):
+    """Upgrade kitconcept.solr to the latest profile version, if installed.
+
+    The distribution installs kitconcept.solr only on sites created with
+    Solr support, so bail out when the profile was never applied.
+    """
+    if setup_tool.getLastVersionForProfile(SOLR_PROFILE_ID) == UNKNOWN:
+        logger.info(f"{SOLR_PROFILE_ID} is not installed, nothing to upgrade")
+        return
+    if setup_tool.hasPendingUpgrades(SOLR_PROFILE_ID):
+        setup_tool.upgradeProfile(SOLR_PROFILE_ID)
+        current_version = setup_tool.getLastVersionForProfile(SOLR_PROFILE_ID)
+        logger.info(f"Upgraded {SOLR_PROFILE_ID} to version {current_version}")
+    else:
+        logger.info(f"{SOLR_PROFILE_ID} is already up to date")

--- a/backend/src/kitconcept/intranet/upgrades/v20260729001/configure.zcml
+++ b/backend/src/kitconcept/intranet/upgrades/v20260729001/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    >
+  <genericsetup:upgradeSteps
+      profile="kitconcept.intranet:default"
+      source="20260728001"
+      destination="20260729001"
+      >
+    <genericsetup:upgradeStep
+        title="Upgrade kitconcept.solr (AI search support), if installed"
+        handler=".upgrade_kitconcept_solr"
+        />
+  </genericsetup:upgradeSteps>
+</configure>

--- a/backend/tests/upgrades/test_v20260729001.py
+++ b/backend/tests/upgrades/test_v20260729001.py
@@ -1,0 +1,50 @@
+from kitconcept.intranet.upgrades.v20260729001 import SOLR_PROFILE_ID
+from kitconcept.intranet.upgrades.v20260729001 import upgrade_kitconcept_solr
+from Products.GenericSetup.tool import UNKNOWN
+
+import pytest
+
+
+class TestUpgradeKitconceptSolr:
+    """The upgrade step cascades the kitconcept.solr profile upgrade.
+
+    The default test site is created without Solr support
+    (setup_solr: False), which is exactly the bail-out scenario; the
+    upgrade scenario installs the profile and rolls its version back to
+    simulate an existing deployment.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, portal):
+        self.portal = portal
+        self.setup_tool = portal.portal_setup
+
+    def test_bails_out_when_not_installed(self):
+        assert self.setup_tool.getLastVersionForProfile(SOLR_PROFILE_ID) == UNKNOWN
+        upgrade_kitconcept_solr(self.setup_tool)
+        # still not installed: the step must not import the profile
+        assert self.setup_tool.getLastVersionForProfile(SOLR_PROFILE_ID) == UNKNOWN
+
+    def test_upgrades_installed_profile(self):
+        setup_tool = self.setup_tool
+        setup_tool.runAllImportStepsFromProfile(f"profile-{SOLR_PROFILE_ID}")
+        # simulate a deployment installed before the AI search support
+        setup_tool.setLastVersionForProfile(SOLR_PROFILE_ID, "1003")
+        assert setup_tool.hasPendingUpgrades(SOLR_PROFILE_ID)
+
+        upgrade_kitconcept_solr(setup_tool)
+
+        assert not setup_tool.hasPendingUpgrades(SOLR_PROFILE_ID)
+        version = setup_tool.getLastVersionForProfile(SOLR_PROFILE_ID)
+        assert version == ("1004",)
+        # the 1003 -> 1004 step adds the AI search toggle registry record
+        from plone import api
+
+        assert api.portal.get_registry_record("kitconcept.solr.rag_enabled") is False
+
+    def test_noop_when_already_up_to_date(self):
+        setup_tool = self.setup_tool
+        setup_tool.runAllImportStepsFromProfile(f"profile-{SOLR_PROFILE_ID}")
+        assert not setup_tool.hasPendingUpgrades(SOLR_PROFILE_ID)
+        upgrade_kitconcept_solr(setup_tool)
+        assert not setup_tool.hasPendingUpgrades(SOLR_PROFILE_ID)


### PR DESCRIPTION
Follow-up to #436 addressing the deployment review points (refs gitlab #433 / deployment ticket #515).

## Upgrade step v20260729001: upgrade kitconcept.solr if installed

On existing deployments only the distribution's own upgrade steps run, so the new kitconcept.solr profile version (1004: `rag_enabled` registry record + RAG indexing queue processor) would never be applied. This cascades it from a kitconcept.intranet upgrade step, following the existing collective.person pattern (v20250909001). Bails out when kitconcept.solr was never installed (sites created without Solr support).

Note this is required for the deploy command to work at all on the existing io site: its kitconcept.solr profile is still at 1003, so the `rag_enabled` record does not exist yet and `solr_activate_and_reindex.py --rag-enable` would fail on `set_registry_record` until the site upgrade has run.

**Testing** (no Solr server needed): the default test site is created with `setup_solr: false`, which is the bail-out scenario; the upgrade scenario installs `kitconcept.solr:default` in-test (registry import only) and rolls its version back to 1003 to simulate an existing deployment. See `backend/tests/upgrades/test_v20260729001.py`.

## Docs: cluster deployment of the AI search reindex

The make targets are dev-only; in the docker image the reindex runs as

```sh
./docker-entrypoint.sh run ./scripts/solr_activate_and_reindex.py --rag-enable --clear
```

Documents the required order: LLM credentials on the container first (the RAG processor silently skips embedding without them — the reindex "succeeds" with an empty chunk index), then the site upgrade, then the reindex. Also notes the site id and the `--rag-disable` rollback switch.