### PR TITLE
Workspace search dialog: livesearch and AI answers (#426)

### DIFF
--- a/backend/news/+solr-pin-update.internal
+++ b/backend/news/+solr-pin-update.internal
@@ -1,0 +1,1 @@
+Update the kitconcept-solr pin to the current feature-ai-rag tip (hybrid retrieval and latest fixes included in CI and deployments). @reebalazs

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.14.*"
 
 [options]
@@ -1589,7 +1589,7 @@ provides-extras = ["test"]
 [[package]]
 name = "kitconcept-solr"
 version = "2.0.0a14"
-source = { git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&branch=feature-ai-rag#7f5ba8c1c12ba60f3fdf40519e5ae0dc7363e9d5" }
+source = { git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&branch=feature-ai-rag#397e09bc498e8431850c7be8c221c000a89aadf9" }
 dependencies = [
     { name = "collective-solr" },
     { name = "plone-api" },

--- a/frontend/packages/kitconcept-intranet/locales/de/LC_MESSAGES/volto.po
+++ b/frontend/packages/kitconcept-intranet/locales/de/LC_MESSAGES/volto.po
@@ -11,15 +11,60 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
+#. Default: "AI Overview"
+#: components/Header/HeaderSearch
+msgid "AI Overview"
+msgstr "KI-Überblick"
+
+#. Default: "AI-generated answer. It may contain errors."
+#: components/Header/HeaderSearch
+msgid "AI-generated answer. It may contain errors."
+msgstr "KI-generierte Antwort. Kann Fehler enthalten."
+
 #. Default: "Address"
 #: components/theme/PersonView
 msgid "Address"
 msgstr "Adresse"
 
+#. Default: "All"
+#: components/Header/HeaderSearch
+msgid "All"
+msgstr "Alle"
+
+#. Default: "All statuses"
+#: components/Header/HeaderSearch
+msgid "All statuses"
+msgstr "Alle Status"
+
+#. Default: "All types"
+#: components/Header/HeaderSearch
+msgid "All types"
+msgstr "Alle Typen"
+
+#. Default: "Any time"
+#: components/Header/HeaderSearch
+msgid "Any time"
+msgstr "Jederzeit"
+
+#. Default: "Ask AI"
+#: components/Header/HeaderSearch
+msgid "Ask AI"
+msgstr "KI fragen"
+
+#. Default: "Ask a follow-up…"
+#: components/Header/HeaderSearch
+msgid "Ask a follow-up…"
+msgstr "Rückfrage stellen…"
+
 #. Default: "Assignee: *"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "Assignee"
 msgstr "Beauftragte Person: *"
+
+#. Default: "Beta"
+#: components/Header/HeaderSearch
+msgid "Beta"
+msgstr "Beta"
 
 #. Default: "Bio"
 #: components/theme/PersonView
@@ -65,6 +110,11 @@ msgstr ""
 msgid "Created On"
 msgstr "Erstellt am"
 
+#. Default: "Created by"
+#: components/Header/HeaderSearch
+msgid "Created by"
+msgstr "Erstellt von"
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -104,6 +154,11 @@ msgstr "Ende"
 msgid "Error"
 msgstr "Fehler"
 
+#. Default: "Event"
+#: components/Header/HeaderSearch
+msgid "Event"
+msgstr "Termin"
+
 #. Default: "Expand sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Expand sidebar"
@@ -134,20 +189,65 @@ msgstr "Feedback zu:"
 msgid "Feedback to:"
 msgstr "Feedback an:"
 
-#. Default: "Follow us:"
-#: components/Footer/slots/FollowUsLogoAndLinks
-msgid "Follow us:"
-msgstr "Folgen Sie uns:"
+#. Default: "File"
+#: components/Header/HeaderSearch
+msgid "File"
+msgstr "Datei"
+
+#. Default: "Folder"
+#: components/Header/HeaderSearch
+msgid "Folder"
+msgstr "Ordner"
+
+#. Default: "Generating answer…"
+#: components/Header/HeaderSearch
+msgid "Generating answer…"
+msgstr "Antwort wird erstellt …"
+
+#. Default: "Home"
+#: components/Header/HeaderBreadcrumbs
+msgid "Home"
+msgstr ""
 
 #. Default: "ICS Download"
 #: components/Blocks/EventMetadata/View
 msgid "ICS-Download"
 msgstr "Zum Kalendar hinzufügen"
 
+#. Default: "Image"
+#: components/Header/HeaderSearch
+msgid "Image"
+msgstr "Bild"
+
+#. Default: "In review"
+#: components/Header/HeaderSearch
+msgid "In review"
+msgstr "In Prüfung"
+
+#. Default: "Intranet Portal"
+#: components/Header/HeaderSearch
+msgid "Intranet Portal"
+msgstr "Intranet Portal"
+
 #. Default: "Invalid url"
 #: components/Blocks/IFrame/isValidUrl
 msgid "Invalid url"
 msgstr "Ungültige URL"
+
+#. Default: "Last 3 months"
+#: components/Header/HeaderSearch
+msgid "Last 3 months"
+msgstr "Letzte 3 Monate"
+
+#. Default: "Last 30 days"
+#: components/Header/HeaderSearch
+msgid "Last 30 days"
+msgstr "Letzte 30 Tage"
+
+#. Default: "Last 7 days"
+#: components/Header/HeaderSearch
+msgid "Last 7 days"
+msgstr "Letzte 7 Tage"
 
 #. Default: "Last Modified On"
 #: components/ContentInteractions/ContentInteractions
@@ -158,6 +258,11 @@ msgstr "Zuletzt geändert am"
 #: components/Toolbar/DocumentReview
 msgid "Last updated"
 msgstr ""
+
+#. Default: "Last year"
+#: components/Header/HeaderSearch
+msgid "Last year"
+msgstr "Letztes Jahr"
 
 #. Default: "List with date"
 #: index
@@ -184,10 +289,25 @@ msgstr "Als geprüft markieren"
 msgid "Name"
 msgstr "Name"
 
+#. Default: "News Item"
+#: components/Header/HeaderSearch
+msgid "News Item"
+msgstr "Nachricht"
+
 #. Default: "Next review"
 #: components/Toolbar/DocumentReview
 msgid "Next review"
 msgstr ""
+
+#. Default: "No answer — no matching documents found."
+#: components/Header/HeaderSearch
+msgid "No answer — no matching documents found."
+msgstr "Keine Antwort — keine passenden Dokumente gefunden."
+
+#. Default: "No results for “{term}”."
+#: components/Header/HeaderSearch
+msgid "No results for “{term}”."
+msgstr "Keine Ergebnisse für „{term}“."
 
 #. Default: "Only internal e-mail addresses are permitted."
 #: components/FeedBackForm/FeedBackForm
@@ -198,6 +318,16 @@ msgstr "Es sind nur interne E-Mail-Adressen zulässig."
 #: index
 msgid "Organisational Unit"
 msgstr "Organisationseinheit"
+
+#. Default: "Page"
+#: components/Header/HeaderSearch
+msgid "Page"
+msgstr "Seite"
+
+#. Default: "Person"
+#: components/Header/HeaderSearch
+msgid "Person"
+msgstr "Person"
 
 #. Default: "Phone"
 #: components/Blocks/EventMetadata/View
@@ -231,6 +361,16 @@ msgstr "Überprüfung verschieben"
 msgid "PostponeTitle"
 msgstr "Überprüfung verschieben"
 
+#. Default: "Private"
+#: components/Header/HeaderSearch
+msgid "Private"
+msgstr "Privat"
+
+#. Default: "Published"
+#: components/Header/HeaderSearch
+msgid "Published"
+msgstr "Veröffentlicht"
+
 #. Default: "Responsibilities"
 #: index
 msgid "Responsibilities"
@@ -247,6 +387,26 @@ msgstr "Inhaltsprüfung"
 #: components/theme/PersonView
 msgid "Room"
 msgstr "Raum"
+
+#. Default: "Search"
+#: components/Header/HeaderSearch
+msgid "Search"
+msgstr ""
+
+#. Default: "Search titles only"
+#: components/Header/HeaderSearch
+msgid "Search titles only"
+msgstr "Nur Titel durchsuchen"
+
+#. Default: "Search workspace"
+#: components/Header/HeaderSearch
+msgid "Search workspace"
+msgstr "Workspace durchsuchen"
+
+#. Default: "Search…"
+#: components/Header/HeaderSearch
+msgid "Search…"
+msgstr "Suchen…"
 
 #. Default: "Please Select ..."
 #: components/ContentReviewSidebar/DelegateReview
@@ -268,6 +428,16 @@ msgstr "Ich möchte diesen Intranet-Inhalt mit Ihnen teilen:"
 msgid "Share this page via email"
 msgstr "Seite per E-Mail teilen"
 
+#. Default: "Show archived content"
+#: components/Header/HeaderSearch
+msgid "Show archived content"
+msgstr "Archivierte Inhalte anzeigen"
+
+#. Default: "Show more breadcrumb items"
+#: components/Header/HeaderBreadcrumbs
+msgid "Show more breadcrumb items"
+msgstr ""
+
 #. Default: "Shrink sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Shrink sidebar"
@@ -277,6 +447,11 @@ msgstr ""
 #: components/theme/PersonView
 msgid "Site"
 msgstr "Website"
+
+#. Default: "Site Setup"
+#: components/Header/useHeaderBreadcrumbs
+msgid "Site Setup"
+msgstr ""
 
 #. Default: "Something went wrong while liking this post."
 #: components/ContentInteractions/ContentInteractions
@@ -288,6 +463,11 @@ msgstr "Beim Liken dieses Beitrags ist ein Fehler aufgetreten."
 msgid "Something went wrong while unliking this post."
 msgstr "Beim Entliken dieses Beitrags ist ein Fehler aufgetreten."
 
+#. Default: "Sources"
+#: components/Header/HeaderSearch
+msgid "Sources"
+msgstr "Quellen"
+
 #. Default: "Sponsored by:"
 #: components/Footer/slots/FollowUsLogoAndLinks
 msgid "Sponsored by:"
@@ -297,6 +477,16 @@ msgstr "Gesponsert von:"
 #: components/Blocks/EventMetadata/View
 msgid "Start"
 msgstr "Anfang"
+
+#. Default: "Start typing to search…"
+#: components/Header/HeaderSearch
+msgid "Start typing to search…"
+msgstr "Tippen Sie, um zu suchen…"
+
+#. Default: "Status"
+#: components/Header/HeaderSearch
+msgid "Status"
+msgstr "Status"
 
 #. Default: "Subject page/URL"
 #: components/FeedBackForm/FeedBackForm
@@ -311,6 +501,11 @@ msgstr "Betreff Seite/URL"
 msgid "Success"
 msgstr "Erfolg"
 
+#. Default: "The AI answer is currently unavailable. Please try again."
+#: components/Header/HeaderSearch
+msgid "The AI answer is currently unavailable. Please try again."
+msgstr "Die KI-Antwort ist momentan nicht verfügbar. Bitte versuchen Sie es erneut."
+
 #. Default: "The displayed content is tailored to your organizational unit and location."
 #: slots/ListingDisclaimer/ListingDisclaimer
 msgid "The displayed content is tailored to your organizational unit and location."
@@ -321,6 +516,21 @@ msgstr "Die angezeigten Inhalte wurden anhand Deiner Organisationseinheit und De
 msgid "To submit a Like you must be logged in"
 msgstr "Um ein „Gefällt mir“ abzugeben, müssen Sie angemeldet sein."
 
+#. Default: "Today"
+#: components/Header/HeaderSearch
+msgid "Today"
+msgstr "Heute"
+
+#. Default: "Type"
+#: components/Header/HeaderSearch
+msgid "Type"
+msgstr "Typ"
+
+#. Default: "Updated"
+#: components/Header/HeaderSearch
+msgid "Updated"
+msgstr "Aktualisiert"
+
 #. Default: "Use preset review interval"
 #: components/ContentReviewSidebar/PostponeReview
 msgid "Use preset review interval"
@@ -330,6 +540,11 @@ msgstr "Voreingestelltes Überprüfungsintervall verwenden."
 #: components/Blocks/EventMetadata/View
 msgid "Website"
 msgstr "Website"
+
+#. Default: "Workspace"
+#: components/Header/HeaderSearch
+msgid "Workspace"
+msgstr "Workspace"
 
 #. Default: "Your feedback has been submitted successfully. You will receive a confirmation email shortly."
 #: components/FeedBackForm/FeedBackForm
@@ -370,6 +585,106 @@ msgstr "Die Überprüfung wurde erfolgreich verschoben."
 #: slots/DocumentByLine/DocumentByLine
 msgid "modified"
 msgstr "zuletzt verändert"
+
+#. Default: "Something went wrong"
+#: components/NavigationTree/messages
+msgid "navigation_tree_action_error"
+msgstr ""
+
+#. Default: "Add new"
+#: components/NavigationTree/messages
+msgid "navigation_tree_add_new"
+msgstr ""
+
+#. Default: "Clear search"
+#: components/NavigationTree/messages
+msgid "navigation_tree_clear_search"
+msgstr ""
+
+#. Default: "Close navigation tree"
+#: components/NavigationTree/messages
+msgid "navigation_tree_close_panel"
+msgstr ""
+
+#. Default: "Delete"
+#: components/NavigationTree/messages
+msgid "navigation_tree_delete"
+msgstr ""
+
+#. Default: "Duplicate"
+#: components/NavigationTree/messages
+msgid "navigation_tree_duplicate"
+msgstr ""
+
+#. Default: "Loading…"
+#: components/NavigationTree/messages
+msgid "navigation_tree_loading"
+msgstr ""
+
+#. Default: "More actions"
+#: components/NavigationTree/messages
+msgid "navigation_tree_more_actions"
+msgstr ""
+
+#. Default: "NAVIGATION"
+#: components/NavigationTree/messages
+msgid "navigation_tree_navigation_label"
+msgstr ""
+
+#. Default: "No results found"
+#: components/NavigationTree/messages
+msgid "navigation_tree_no_results"
+msgstr ""
+
+#. Default: "Open navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_open_navigation"
+msgstr ""
+
+#. Default: "Rename"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename"
+msgstr ""
+
+#. Default: "Title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename_title_label"
+msgstr ""
+
+#. Default: "Resize navigation panel"
+#: components/NavigationTree/messages
+msgid "navigation_tree_resize_panel"
+msgstr ""
+
+#. Default: "Search navigation by title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_aria_label"
+msgstr ""
+
+#. Default: "Search by title..."
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_placeholder"
+msgstr ""
+
+#. Default: "Search results"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_results"
+msgstr ""
+
+#. Default: "SITE"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_label"
+msgstr ""
+
+#. Default: "Site navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_navigation"
+msgstr ""
+
+#. Default: "Switch workspace"
+#: components/NavigationTree/messages
+msgid "navigation_tree_workspace_switcher_label"
+msgstr ""
 
 #. Default: "Next Review on:"
 #: components/ContentReviewSidebar/PostponeReview

--- a/frontend/packages/kitconcept-intranet/locales/en/LC_MESSAGES/volto.po
+++ b/frontend/packages/kitconcept-intranet/locales/en/LC_MESSAGES/volto.po
@@ -11,14 +11,59 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
+#. Default: "AI Overview"
+#: components/Header/HeaderSearch
+msgid "AI Overview"
+msgstr ""
+
+#. Default: "AI-generated answer. It may contain errors."
+#: components/Header/HeaderSearch
+msgid "AI-generated answer. It may contain errors."
+msgstr ""
+
 #. Default: "Address"
 #: components/theme/PersonView
 msgid "Address"
 msgstr "Adresse"
 
+#. Default: "All"
+#: components/Header/HeaderSearch
+msgid "All"
+msgstr ""
+
+#. Default: "All statuses"
+#: components/Header/HeaderSearch
+msgid "All statuses"
+msgstr ""
+
+#. Default: "All types"
+#: components/Header/HeaderSearch
+msgid "All types"
+msgstr ""
+
+#. Default: "Any time"
+#: components/Header/HeaderSearch
+msgid "Any time"
+msgstr ""
+
+#. Default: "Ask AI"
+#: components/Header/HeaderSearch
+msgid "Ask AI"
+msgstr ""
+
+#. Default: "Ask a follow-up…"
+#: components/Header/HeaderSearch
+msgid "Ask a follow-up…"
+msgstr ""
+
 #. Default: "Assignee: *"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "Assignee"
+msgstr ""
+
+#. Default: "Beta"
+#: components/Header/HeaderSearch
+msgid "Beta"
 msgstr ""
 
 #. Default: "Bio"
@@ -65,6 +110,11 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
+#. Default: "Created by"
+#: components/Header/HeaderSearch
+msgid "Created by"
+msgstr ""
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -104,6 +154,11 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#. Default: "Event"
+#: components/Header/HeaderSearch
+msgid "Event"
+msgstr ""
+
 #. Default: "Expand sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Expand sidebar"
@@ -134,9 +189,24 @@ msgstr ""
 msgid "Feedback to:"
 msgstr ""
 
-#. Default: "Follow us:"
-#: components/Footer/slots/FollowUsLogoAndLinks
-msgid "Follow us:"
+#. Default: "File"
+#: components/Header/HeaderSearch
+msgid "File"
+msgstr ""
+
+#. Default: "Folder"
+#: components/Header/HeaderSearch
+msgid "Folder"
+msgstr ""
+
+#. Default: "Generating answer…"
+#: components/Header/HeaderSearch
+msgid "Generating answer…"
+msgstr ""
+
+#. Default: "Home"
+#: components/Header/HeaderBreadcrumbs
+msgid "Home"
 msgstr ""
 
 #. Default: "ICS Download"
@@ -144,9 +214,39 @@ msgstr ""
 msgid "ICS-Download"
 msgstr ""
 
+#. Default: "Image"
+#: components/Header/HeaderSearch
+msgid "Image"
+msgstr ""
+
+#. Default: "In review"
+#: components/Header/HeaderSearch
+msgid "In review"
+msgstr ""
+
+#. Default: "Intranet Portal"
+#: components/Header/HeaderSearch
+msgid "Intranet Portal"
+msgstr ""
+
 #. Default: "Invalid url"
 #: components/Blocks/IFrame/isValidUrl
 msgid "Invalid url"
+msgstr ""
+
+#. Default: "Last 3 months"
+#: components/Header/HeaderSearch
+msgid "Last 3 months"
+msgstr ""
+
+#. Default: "Last 30 days"
+#: components/Header/HeaderSearch
+msgid "Last 30 days"
+msgstr ""
+
+#. Default: "Last 7 days"
+#: components/Header/HeaderSearch
+msgid "Last 7 days"
 msgstr ""
 
 #. Default: "Last Modified On"
@@ -157,6 +257,11 @@ msgstr ""
 #. Default: "Last updated"
 #: components/Toolbar/DocumentReview
 msgid "Last updated"
+msgstr ""
+
+#. Default: "Last year"
+#: components/Header/HeaderSearch
+msgid "Last year"
 msgstr ""
 
 #. Default: "List with date"
@@ -184,9 +289,24 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+#. Default: "News Item"
+#: components/Header/HeaderSearch
+msgid "News Item"
+msgstr ""
+
 #. Default: "Next review"
 #: components/Toolbar/DocumentReview
 msgid "Next review"
+msgstr ""
+
+#. Default: "No answer — no matching documents found."
+#: components/Header/HeaderSearch
+msgid "No answer — no matching documents found."
+msgstr ""
+
+#. Default: "No results for “{term}”."
+#: components/Header/HeaderSearch
+msgid "No results for “{term}”."
 msgstr ""
 
 #. Default: "Only internal e-mail addresses are permitted."
@@ -197,6 +317,16 @@ msgstr ""
 #. Default: "Organisational Unit"
 #: index
 msgid "Organisational Unit"
+msgstr ""
+
+#. Default: "Page"
+#: components/Header/HeaderSearch
+msgid "Page"
+msgstr ""
+
+#. Default: "Person"
+#: components/Header/HeaderSearch
+msgid "Person"
 msgstr ""
 
 #. Default: "Phone"
@@ -231,6 +361,16 @@ msgstr ""
 msgid "PostponeTitle"
 msgstr ""
 
+#. Default: "Private"
+#: components/Header/HeaderSearch
+msgid "Private"
+msgstr ""
+
+#. Default: "Published"
+#: components/Header/HeaderSearch
+msgid "Published"
+msgstr ""
+
 #. Default: "Responsibilities"
 #: index
 msgid "Responsibilities"
@@ -246,6 +386,26 @@ msgstr ""
 #: components/Summary/PersonSummary
 #: components/theme/PersonView
 msgid "Room"
+msgstr ""
+
+#. Default: "Search"
+#: components/Header/HeaderSearch
+msgid "Search"
+msgstr ""
+
+#. Default: "Search titles only"
+#: components/Header/HeaderSearch
+msgid "Search titles only"
+msgstr ""
+
+#. Default: "Search workspace"
+#: components/Header/HeaderSearch
+msgid "Search workspace"
+msgstr ""
+
+#. Default: "Search…"
+#: components/Header/HeaderSearch
+msgid "Search…"
 msgstr ""
 
 #. Default: "Please Select ..."
@@ -268,6 +428,16 @@ msgstr ""
 msgid "Share this page via email"
 msgstr ""
 
+#. Default: "Show archived content"
+#: components/Header/HeaderSearch
+msgid "Show archived content"
+msgstr ""
+
+#. Default: "Show more breadcrumb items"
+#: components/Header/HeaderBreadcrumbs
+msgid "Show more breadcrumb items"
+msgstr ""
+
 #. Default: "Shrink sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Shrink sidebar"
@@ -277,6 +447,11 @@ msgstr ""
 #: components/theme/PersonView
 msgid "Site"
 msgstr "Website"
+
+#. Default: "Site Setup"
+#: components/Header/useHeaderBreadcrumbs
+msgid "Site Setup"
+msgstr ""
 
 #. Default: "Something went wrong while liking this post."
 #: components/ContentInteractions/ContentInteractions
@@ -288,6 +463,11 @@ msgstr ""
 msgid "Something went wrong while unliking this post."
 msgstr ""
 
+#. Default: "Sources"
+#: components/Header/HeaderSearch
+msgid "Sources"
+msgstr ""
+
 #. Default: "Sponsored by:"
 #: components/Footer/slots/FollowUsLogoAndLinks
 msgid "Sponsored by:"
@@ -296,6 +476,16 @@ msgstr ""
 #. Default: "Start"
 #: components/Blocks/EventMetadata/View
 msgid "Start"
+msgstr ""
+
+#. Default: "Start typing to search…"
+#: components/Header/HeaderSearch
+msgid "Start typing to search…"
+msgstr ""
+
+#. Default: "Status"
+#: components/Header/HeaderSearch
+msgid "Status"
 msgstr ""
 
 #. Default: "Subject page/URL"
@@ -311,6 +501,11 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
+#. Default: "The AI answer is currently unavailable. Please try again."
+#: components/Header/HeaderSearch
+msgid "The AI answer is currently unavailable. Please try again."
+msgstr ""
+
 #. Default: "The displayed content is tailored to your organizational unit and location."
 #: slots/ListingDisclaimer/ListingDisclaimer
 msgid "The displayed content is tailored to your organizational unit and location."
@@ -321,6 +516,21 @@ msgstr ""
 msgid "To submit a Like you must be logged in"
 msgstr ""
 
+#. Default: "Today"
+#: components/Header/HeaderSearch
+msgid "Today"
+msgstr ""
+
+#. Default: "Type"
+#: components/Header/HeaderSearch
+msgid "Type"
+msgstr ""
+
+#. Default: "Updated"
+#: components/Header/HeaderSearch
+msgid "Updated"
+msgstr ""
+
 #. Default: "Use preset review interval"
 #: components/ContentReviewSidebar/PostponeReview
 msgid "Use preset review interval"
@@ -329,6 +539,11 @@ msgstr ""
 #. Default: "Website"
 #: components/Blocks/EventMetadata/View
 msgid "Website"
+msgstr ""
+
+#. Default: "Workspace"
+#: components/Header/HeaderSearch
+msgid "Workspace"
 msgstr ""
 
 #. Default: "Your feedback has been submitted successfully. You will receive a confirmation email shortly."
@@ -369,6 +584,106 @@ msgstr ""
 #. Default: "last modified"
 #: slots/DocumentByLine/DocumentByLine
 msgid "modified"
+msgstr ""
+
+#. Default: "Something went wrong"
+#: components/NavigationTree/messages
+msgid "navigation_tree_action_error"
+msgstr ""
+
+#. Default: "Add new"
+#: components/NavigationTree/messages
+msgid "navigation_tree_add_new"
+msgstr ""
+
+#. Default: "Clear search"
+#: components/NavigationTree/messages
+msgid "navigation_tree_clear_search"
+msgstr ""
+
+#. Default: "Close navigation tree"
+#: components/NavigationTree/messages
+msgid "navigation_tree_close_panel"
+msgstr ""
+
+#. Default: "Delete"
+#: components/NavigationTree/messages
+msgid "navigation_tree_delete"
+msgstr ""
+
+#. Default: "Duplicate"
+#: components/NavigationTree/messages
+msgid "navigation_tree_duplicate"
+msgstr ""
+
+#. Default: "Loading…"
+#: components/NavigationTree/messages
+msgid "navigation_tree_loading"
+msgstr ""
+
+#. Default: "More actions"
+#: components/NavigationTree/messages
+msgid "navigation_tree_more_actions"
+msgstr ""
+
+#. Default: "NAVIGATION"
+#: components/NavigationTree/messages
+msgid "navigation_tree_navigation_label"
+msgstr ""
+
+#. Default: "No results found"
+#: components/NavigationTree/messages
+msgid "navigation_tree_no_results"
+msgstr ""
+
+#. Default: "Open navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_open_navigation"
+msgstr ""
+
+#. Default: "Rename"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename"
+msgstr ""
+
+#. Default: "Title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename_title_label"
+msgstr ""
+
+#. Default: "Resize navigation panel"
+#: components/NavigationTree/messages
+msgid "navigation_tree_resize_panel"
+msgstr ""
+
+#. Default: "Search navigation by title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_aria_label"
+msgstr ""
+
+#. Default: "Search by title..."
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_placeholder"
+msgstr ""
+
+#. Default: "Search results"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_results"
+msgstr ""
+
+#. Default: "SITE"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_label"
+msgstr ""
+
+#. Default: "Site navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_navigation"
+msgstr ""
+
+#. Default: "Switch workspace"
+#: components/NavigationTree/messages
+msgid "navigation_tree_workspace_switcher_label"
 msgstr ""
 
 #. Default: "Next Review on:"

--- a/frontend/packages/kitconcept-intranet/locales/es/LC_MESSAGES/volto.po
+++ b/frontend/packages/kitconcept-intranet/locales/es/LC_MESSAGES/volto.po
@@ -18,14 +18,59 @@ msgstr ""
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
 "X-Generator: Poedit 2.2.1\n"
 
+#. Default: "AI Overview"
+#: components/Header/HeaderSearch
+msgid "AI Overview"
+msgstr ""
+
+#. Default: "AI-generated answer. It may contain errors."
+#: components/Header/HeaderSearch
+msgid "AI-generated answer. It may contain errors."
+msgstr ""
+
 #. Default: "Address"
 #: components/theme/PersonView
 msgid "Address"
 msgstr ""
 
+#. Default: "All"
+#: components/Header/HeaderSearch
+msgid "All"
+msgstr ""
+
+#. Default: "All statuses"
+#: components/Header/HeaderSearch
+msgid "All statuses"
+msgstr ""
+
+#. Default: "All types"
+#: components/Header/HeaderSearch
+msgid "All types"
+msgstr ""
+
+#. Default: "Any time"
+#: components/Header/HeaderSearch
+msgid "Any time"
+msgstr ""
+
+#. Default: "Ask AI"
+#: components/Header/HeaderSearch
+msgid "Ask AI"
+msgstr ""
+
+#. Default: "Ask a follow-up…"
+#: components/Header/HeaderSearch
+msgid "Ask a follow-up…"
+msgstr ""
+
 #. Default: "Assignee: *"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "Assignee"
+msgstr ""
+
+#. Default: "Beta"
+#: components/Header/HeaderSearch
+msgid "Beta"
 msgstr ""
 
 #. Default: "Bio"
@@ -72,6 +117,11 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
+#. Default: "Created by"
+#: components/Header/HeaderSearch
+msgid "Created by"
+msgstr ""
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -111,6 +161,11 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#. Default: "Event"
+#: components/Header/HeaderSearch
+msgid "Event"
+msgstr ""
+
 #. Default: "Expand sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Expand sidebar"
@@ -141,9 +196,24 @@ msgstr ""
 msgid "Feedback to:"
 msgstr ""
 
-#. Default: "Follow us:"
-#: components/Footer/slots/FollowUsLogoAndLinks
-msgid "Follow us:"
+#. Default: "File"
+#: components/Header/HeaderSearch
+msgid "File"
+msgstr ""
+
+#. Default: "Folder"
+#: components/Header/HeaderSearch
+msgid "Folder"
+msgstr ""
+
+#. Default: "Generating answer…"
+#: components/Header/HeaderSearch
+msgid "Generating answer…"
+msgstr ""
+
+#. Default: "Home"
+#: components/Header/HeaderBreadcrumbs
+msgid "Home"
 msgstr ""
 
 #. Default: "ICS Download"
@@ -151,9 +221,39 @@ msgstr ""
 msgid "ICS-Download"
 msgstr ""
 
+#. Default: "Image"
+#: components/Header/HeaderSearch
+msgid "Image"
+msgstr ""
+
+#. Default: "In review"
+#: components/Header/HeaderSearch
+msgid "In review"
+msgstr ""
+
+#. Default: "Intranet Portal"
+#: components/Header/HeaderSearch
+msgid "Intranet Portal"
+msgstr ""
+
 #. Default: "Invalid url"
 #: components/Blocks/IFrame/isValidUrl
 msgid "Invalid url"
+msgstr ""
+
+#. Default: "Last 3 months"
+#: components/Header/HeaderSearch
+msgid "Last 3 months"
+msgstr ""
+
+#. Default: "Last 30 days"
+#: components/Header/HeaderSearch
+msgid "Last 30 days"
+msgstr ""
+
+#. Default: "Last 7 days"
+#: components/Header/HeaderSearch
+msgid "Last 7 days"
 msgstr ""
 
 #. Default: "Last Modified On"
@@ -164,6 +264,11 @@ msgstr ""
 #. Default: "Last updated"
 #: components/Toolbar/DocumentReview
 msgid "Last updated"
+msgstr ""
+
+#. Default: "Last year"
+#: components/Header/HeaderSearch
+msgid "Last year"
 msgstr ""
 
 #. Default: "List with date"
@@ -191,9 +296,24 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+#. Default: "News Item"
+#: components/Header/HeaderSearch
+msgid "News Item"
+msgstr ""
+
 #. Default: "Next review"
 #: components/Toolbar/DocumentReview
 msgid "Next review"
+msgstr ""
+
+#. Default: "No answer — no matching documents found."
+#: components/Header/HeaderSearch
+msgid "No answer — no matching documents found."
+msgstr ""
+
+#. Default: "No results for “{term}”."
+#: components/Header/HeaderSearch
+msgid "No results for “{term}”."
 msgstr ""
 
 #. Default: "Only internal e-mail addresses are permitted."
@@ -204,6 +324,16 @@ msgstr ""
 #. Default: "Organisational Unit"
 #: index
 msgid "Organisational Unit"
+msgstr ""
+
+#. Default: "Page"
+#: components/Header/HeaderSearch
+msgid "Page"
+msgstr ""
+
+#. Default: "Person"
+#: components/Header/HeaderSearch
+msgid "Person"
 msgstr ""
 
 #. Default: "Phone"
@@ -238,6 +368,16 @@ msgstr ""
 msgid "PostponeTitle"
 msgstr ""
 
+#. Default: "Private"
+#: components/Header/HeaderSearch
+msgid "Private"
+msgstr ""
+
+#. Default: "Published"
+#: components/Header/HeaderSearch
+msgid "Published"
+msgstr ""
+
 #. Default: "Responsibilities"
 #: index
 msgid "Responsibilities"
@@ -253,6 +393,26 @@ msgstr ""
 #: components/Summary/PersonSummary
 #: components/theme/PersonView
 msgid "Room"
+msgstr ""
+
+#. Default: "Search"
+#: components/Header/HeaderSearch
+msgid "Search"
+msgstr ""
+
+#. Default: "Search titles only"
+#: components/Header/HeaderSearch
+msgid "Search titles only"
+msgstr ""
+
+#. Default: "Search workspace"
+#: components/Header/HeaderSearch
+msgid "Search workspace"
+msgstr ""
+
+#. Default: "Search…"
+#: components/Header/HeaderSearch
+msgid "Search…"
 msgstr ""
 
 #. Default: "Please Select ..."
@@ -275,6 +435,16 @@ msgstr ""
 msgid "Share this page via email"
 msgstr ""
 
+#. Default: "Show archived content"
+#: components/Header/HeaderSearch
+msgid "Show archived content"
+msgstr ""
+
+#. Default: "Show more breadcrumb items"
+#: components/Header/HeaderBreadcrumbs
+msgid "Show more breadcrumb items"
+msgstr ""
+
 #. Default: "Shrink sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Shrink sidebar"
@@ -283,6 +453,11 @@ msgstr ""
 #. Default: "Site"
 #: components/theme/PersonView
 msgid "Site"
+msgstr ""
+
+#. Default: "Site Setup"
+#: components/Header/useHeaderBreadcrumbs
+msgid "Site Setup"
 msgstr ""
 
 #. Default: "Something went wrong while liking this post."
@@ -295,6 +470,11 @@ msgstr ""
 msgid "Something went wrong while unliking this post."
 msgstr ""
 
+#. Default: "Sources"
+#: components/Header/HeaderSearch
+msgid "Sources"
+msgstr ""
+
 #. Default: "Sponsored by:"
 #: components/Footer/slots/FollowUsLogoAndLinks
 msgid "Sponsored by:"
@@ -303,6 +483,16 @@ msgstr ""
 #. Default: "Start"
 #: components/Blocks/EventMetadata/View
 msgid "Start"
+msgstr ""
+
+#. Default: "Start typing to search…"
+#: components/Header/HeaderSearch
+msgid "Start typing to search…"
+msgstr ""
+
+#. Default: "Status"
+#: components/Header/HeaderSearch
+msgid "Status"
 msgstr ""
 
 #. Default: "Subject page/URL"
@@ -318,6 +508,11 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
+#. Default: "The AI answer is currently unavailable. Please try again."
+#: components/Header/HeaderSearch
+msgid "The AI answer is currently unavailable. Please try again."
+msgstr ""
+
 #. Default: "The displayed content is tailored to your organizational unit and location."
 #: slots/ListingDisclaimer/ListingDisclaimer
 msgid "The displayed content is tailored to your organizational unit and location."
@@ -328,6 +523,21 @@ msgstr ""
 msgid "To submit a Like you must be logged in"
 msgstr ""
 
+#. Default: "Today"
+#: components/Header/HeaderSearch
+msgid "Today"
+msgstr ""
+
+#. Default: "Type"
+#: components/Header/HeaderSearch
+msgid "Type"
+msgstr ""
+
+#. Default: "Updated"
+#: components/Header/HeaderSearch
+msgid "Updated"
+msgstr ""
+
 #. Default: "Use preset review interval"
 #: components/ContentReviewSidebar/PostponeReview
 msgid "Use preset review interval"
@@ -336,6 +546,11 @@ msgstr ""
 #. Default: "Website"
 #: components/Blocks/EventMetadata/View
 msgid "Website"
+msgstr ""
+
+#. Default: "Workspace"
+#: components/Header/HeaderSearch
+msgid "Workspace"
 msgstr ""
 
 #. Default: "Your feedback has been submitted successfully. You will receive a confirmation email shortly."
@@ -376,6 +591,106 @@ msgstr ""
 #. Default: "last modified"
 #: slots/DocumentByLine/DocumentByLine
 msgid "modified"
+msgstr ""
+
+#. Default: "Something went wrong"
+#: components/NavigationTree/messages
+msgid "navigation_tree_action_error"
+msgstr ""
+
+#. Default: "Add new"
+#: components/NavigationTree/messages
+msgid "navigation_tree_add_new"
+msgstr ""
+
+#. Default: "Clear search"
+#: components/NavigationTree/messages
+msgid "navigation_tree_clear_search"
+msgstr ""
+
+#. Default: "Close navigation tree"
+#: components/NavigationTree/messages
+msgid "navigation_tree_close_panel"
+msgstr ""
+
+#. Default: "Delete"
+#: components/NavigationTree/messages
+msgid "navigation_tree_delete"
+msgstr ""
+
+#. Default: "Duplicate"
+#: components/NavigationTree/messages
+msgid "navigation_tree_duplicate"
+msgstr ""
+
+#. Default: "Loading…"
+#: components/NavigationTree/messages
+msgid "navigation_tree_loading"
+msgstr ""
+
+#. Default: "More actions"
+#: components/NavigationTree/messages
+msgid "navigation_tree_more_actions"
+msgstr ""
+
+#. Default: "NAVIGATION"
+#: components/NavigationTree/messages
+msgid "navigation_tree_navigation_label"
+msgstr ""
+
+#. Default: "No results found"
+#: components/NavigationTree/messages
+msgid "navigation_tree_no_results"
+msgstr ""
+
+#. Default: "Open navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_open_navigation"
+msgstr ""
+
+#. Default: "Rename"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename"
+msgstr ""
+
+#. Default: "Title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename_title_label"
+msgstr ""
+
+#. Default: "Resize navigation panel"
+#: components/NavigationTree/messages
+msgid "navigation_tree_resize_panel"
+msgstr ""
+
+#. Default: "Search navigation by title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_aria_label"
+msgstr ""
+
+#. Default: "Search by title..."
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_placeholder"
+msgstr ""
+
+#. Default: "Search results"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_results"
+msgstr ""
+
+#. Default: "SITE"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_label"
+msgstr ""
+
+#. Default: "Site navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_navigation"
+msgstr ""
+
+#. Default: "Switch workspace"
+#: components/NavigationTree/messages
+msgid "navigation_tree_workspace_switcher_label"
 msgstr ""
 
 #. Default: "Next Review on:"

--- a/frontend/packages/kitconcept-intranet/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/frontend/packages/kitconcept-intranet/locales/pt_BR/LC_MESSAGES/volto.po
@@ -16,14 +16,59 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 "Domain: volto\n"
 
+#. Default: "AI Overview"
+#: components/Header/HeaderSearch
+msgid "AI Overview"
+msgstr ""
+
+#. Default: "AI-generated answer. It may contain errors."
+#: components/Header/HeaderSearch
+msgid "AI-generated answer. It may contain errors."
+msgstr ""
+
 #. Default: "Address"
 #: components/theme/PersonView
 msgid "Address"
 msgstr "Endereço"
 
+#. Default: "All"
+#: components/Header/HeaderSearch
+msgid "All"
+msgstr ""
+
+#. Default: "All statuses"
+#: components/Header/HeaderSearch
+msgid "All statuses"
+msgstr ""
+
+#. Default: "All types"
+#: components/Header/HeaderSearch
+msgid "All types"
+msgstr ""
+
+#. Default: "Any time"
+#: components/Header/HeaderSearch
+msgid "Any time"
+msgstr ""
+
+#. Default: "Ask AI"
+#: components/Header/HeaderSearch
+msgid "Ask AI"
+msgstr ""
+
+#. Default: "Ask a follow-up…"
+#: components/Header/HeaderSearch
+msgid "Ask a follow-up…"
+msgstr ""
+
 #. Default: "Assignee: *"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "Assignee"
+msgstr ""
+
+#. Default: "Beta"
+#: components/Header/HeaderSearch
+msgid "Beta"
 msgstr ""
 
 #. Default: "Bio"
@@ -70,6 +115,11 @@ msgstr ""
 msgid "Created On"
 msgstr "Criado em"
 
+#. Default: "Created by"
+#: components/Header/HeaderSearch
+msgid "Created by"
+msgstr ""
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -109,6 +159,11 @@ msgstr "Término"
 msgid "Error"
 msgstr "Erro"
 
+#. Default: "Event"
+#: components/Header/HeaderSearch
+msgid "Event"
+msgstr ""
+
 #. Default: "Expand sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Expand sidebar"
@@ -139,20 +194,65 @@ msgstr "Feedback sobre:"
 msgid "Feedback to:"
 msgstr "Feedback para:"
 
-#. Default: "Follow us:"
-#: components/Footer/slots/FollowUsLogoAndLinks
-msgid "Follow us:"
-msgstr "Acompanhe-nos:"
+#. Default: "File"
+#: components/Header/HeaderSearch
+msgid "File"
+msgstr ""
+
+#. Default: "Folder"
+#: components/Header/HeaderSearch
+msgid "Folder"
+msgstr ""
+
+#. Default: "Generating answer…"
+#: components/Header/HeaderSearch
+msgid "Generating answer…"
+msgstr ""
+
+#. Default: "Home"
+#: components/Header/HeaderBreadcrumbs
+msgid "Home"
+msgstr ""
 
 #. Default: "ICS Download"
 #: components/Blocks/EventMetadata/View
 msgid "ICS-Download"
 msgstr "Baixar ICS"
 
+#. Default: "Image"
+#: components/Header/HeaderSearch
+msgid "Image"
+msgstr ""
+
+#. Default: "In review"
+#: components/Header/HeaderSearch
+msgid "In review"
+msgstr ""
+
+#. Default: "Intranet Portal"
+#: components/Header/HeaderSearch
+msgid "Intranet Portal"
+msgstr ""
+
 #. Default: "Invalid url"
 #: components/Blocks/IFrame/isValidUrl
 msgid "Invalid url"
 msgstr "URL inválida"
+
+#. Default: "Last 3 months"
+#: components/Header/HeaderSearch
+msgid "Last 3 months"
+msgstr ""
+
+#. Default: "Last 30 days"
+#: components/Header/HeaderSearch
+msgid "Last 30 days"
+msgstr ""
+
+#. Default: "Last 7 days"
+#: components/Header/HeaderSearch
+msgid "Last 7 days"
+msgstr ""
 
 #. Default: "Last Modified On"
 #: components/ContentInteractions/ContentInteractions
@@ -162,6 +262,11 @@ msgstr "Última modificação em"
 #. Default: "Last updated"
 #: components/Toolbar/DocumentReview
 msgid "Last updated"
+msgstr ""
+
+#. Default: "Last year"
+#: components/Header/HeaderSearch
+msgid "Last year"
 msgstr ""
 
 #. Default: "List with date"
@@ -189,9 +294,24 @@ msgstr ""
 msgid "Name"
 msgstr "Nome"
 
+#. Default: "News Item"
+#: components/Header/HeaderSearch
+msgid "News Item"
+msgstr ""
+
 #. Default: "Next review"
 #: components/Toolbar/DocumentReview
 msgid "Next review"
+msgstr ""
+
+#. Default: "No answer — no matching documents found."
+#: components/Header/HeaderSearch
+msgid "No answer — no matching documents found."
+msgstr ""
+
+#. Default: "No results for “{term}”."
+#: components/Header/HeaderSearch
+msgid "No results for “{term}”."
 msgstr ""
 
 #. Default: "Only internal e-mail addresses are permitted."
@@ -203,6 +323,16 @@ msgstr "Apenas endereços de e-mail internos são permitidos."
 #: index
 msgid "Organisational Unit"
 msgstr "Área Organizacional"
+
+#. Default: "Page"
+#: components/Header/HeaderSearch
+msgid "Page"
+msgstr ""
+
+#. Default: "Person"
+#: components/Header/HeaderSearch
+msgid "Person"
+msgstr ""
 
 #. Default: "Phone"
 #: components/Blocks/EventMetadata/View
@@ -236,6 +366,16 @@ msgstr ""
 msgid "PostponeTitle"
 msgstr ""
 
+#. Default: "Private"
+#: components/Header/HeaderSearch
+msgid "Private"
+msgstr ""
+
+#. Default: "Published"
+#: components/Header/HeaderSearch
+msgid "Published"
+msgstr ""
+
 #. Default: "Responsibilities"
 #: index
 msgid "Responsibilities"
@@ -252,6 +392,26 @@ msgstr ""
 #: components/theme/PersonView
 msgid "Room"
 msgstr "Sala"
+
+#. Default: "Search"
+#: components/Header/HeaderSearch
+msgid "Search"
+msgstr ""
+
+#. Default: "Search titles only"
+#: components/Header/HeaderSearch
+msgid "Search titles only"
+msgstr ""
+
+#. Default: "Search workspace"
+#: components/Header/HeaderSearch
+msgid "Search workspace"
+msgstr ""
+
+#. Default: "Search…"
+#: components/Header/HeaderSearch
+msgid "Search…"
+msgstr ""
 
 #. Default: "Please Select ..."
 #: components/ContentReviewSidebar/DelegateReview
@@ -273,6 +433,16 @@ msgstr "Gostaria de compartilhar este conteúdo da intranet com você:"
 msgid "Share this page via email"
 msgstr "Compartilhe esta página por e-mail"
 
+#. Default: "Show archived content"
+#: components/Header/HeaderSearch
+msgid "Show archived content"
+msgstr ""
+
+#. Default: "Show more breadcrumb items"
+#: components/Header/HeaderBreadcrumbs
+msgid "Show more breadcrumb items"
+msgstr ""
+
 #. Default: "Shrink sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Shrink sidebar"
@@ -282,6 +452,11 @@ msgstr ""
 #: components/theme/PersonView
 msgid "Site"
 msgstr "Site"
+
+#. Default: "Site Setup"
+#: components/Header/useHeaderBreadcrumbs
+msgid "Site Setup"
+msgstr ""
 
 #. Default: "Something went wrong while liking this post."
 #: components/ContentInteractions/ContentInteractions
@@ -293,6 +468,11 @@ msgstr "Algo deu errado ao curtir esta publicação."
 msgid "Something went wrong while unliking this post."
 msgstr "Algo deu errado ao descurtir esta publicação."
 
+#. Default: "Sources"
+#: components/Header/HeaderSearch
+msgid "Sources"
+msgstr ""
+
 #. Default: "Sponsored by:"
 #: components/Footer/slots/FollowUsLogoAndLinks
 msgid "Sponsored by:"
@@ -302,6 +482,16 @@ msgstr "Apoiado por:"
 #: components/Blocks/EventMetadata/View
 msgid "Start"
 msgstr "Início"
+
+#. Default: "Start typing to search…"
+#: components/Header/HeaderSearch
+msgid "Start typing to search…"
+msgstr ""
+
+#. Default: "Status"
+#: components/Header/HeaderSearch
+msgid "Status"
+msgstr ""
 
 #. Default: "Subject page/URL"
 #: components/FeedBackForm/FeedBackForm
@@ -316,6 +506,11 @@ msgstr "Página/URL do assunto"
 msgid "Success"
 msgstr "Sucesso"
 
+#. Default: "The AI answer is currently unavailable. Please try again."
+#: components/Header/HeaderSearch
+msgid "The AI answer is currently unavailable. Please try again."
+msgstr ""
+
 #. Default: "The displayed content is tailored to your organizational unit and location."
 #: slots/ListingDisclaimer/ListingDisclaimer
 msgid "The displayed content is tailored to your organizational unit and location."
@@ -326,6 +521,21 @@ msgstr "O conteúdo exibido é personalizado para sua área organizacional e loc
 msgid "To submit a Like you must be logged in"
 msgstr "Para curtir, você precisa estar logado"
 
+#. Default: "Today"
+#: components/Header/HeaderSearch
+msgid "Today"
+msgstr ""
+
+#. Default: "Type"
+#: components/Header/HeaderSearch
+msgid "Type"
+msgstr ""
+
+#. Default: "Updated"
+#: components/Header/HeaderSearch
+msgid "Updated"
+msgstr ""
+
 #. Default: "Use preset review interval"
 #: components/ContentReviewSidebar/PostponeReview
 msgid "Use preset review interval"
@@ -335,6 +545,11 @@ msgstr ""
 #: components/Blocks/EventMetadata/View
 msgid "Website"
 msgstr "Site"
+
+#. Default: "Workspace"
+#: components/Header/HeaderSearch
+msgid "Workspace"
+msgstr ""
 
 #. Default: "Your feedback has been submitted successfully. You will receive a confirmation email shortly."
 #: components/FeedBackForm/FeedBackForm
@@ -375,6 +590,106 @@ msgstr ""
 #: slots/DocumentByLine/DocumentByLine
 msgid "modified"
 msgstr "última modificação"
+
+#. Default: "Something went wrong"
+#: components/NavigationTree/messages
+msgid "navigation_tree_action_error"
+msgstr ""
+
+#. Default: "Add new"
+#: components/NavigationTree/messages
+msgid "navigation_tree_add_new"
+msgstr ""
+
+#. Default: "Clear search"
+#: components/NavigationTree/messages
+msgid "navigation_tree_clear_search"
+msgstr ""
+
+#. Default: "Close navigation tree"
+#: components/NavigationTree/messages
+msgid "navigation_tree_close_panel"
+msgstr ""
+
+#. Default: "Delete"
+#: components/NavigationTree/messages
+msgid "navigation_tree_delete"
+msgstr ""
+
+#. Default: "Duplicate"
+#: components/NavigationTree/messages
+msgid "navigation_tree_duplicate"
+msgstr ""
+
+#. Default: "Loading…"
+#: components/NavigationTree/messages
+msgid "navigation_tree_loading"
+msgstr ""
+
+#. Default: "More actions"
+#: components/NavigationTree/messages
+msgid "navigation_tree_more_actions"
+msgstr ""
+
+#. Default: "NAVIGATION"
+#: components/NavigationTree/messages
+msgid "navigation_tree_navigation_label"
+msgstr ""
+
+#. Default: "No results found"
+#: components/NavigationTree/messages
+msgid "navigation_tree_no_results"
+msgstr ""
+
+#. Default: "Open navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_open_navigation"
+msgstr ""
+
+#. Default: "Rename"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename"
+msgstr ""
+
+#. Default: "Title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename_title_label"
+msgstr ""
+
+#. Default: "Resize navigation panel"
+#: components/NavigationTree/messages
+msgid "navigation_tree_resize_panel"
+msgstr ""
+
+#. Default: "Search navigation by title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_aria_label"
+msgstr ""
+
+#. Default: "Search by title..."
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_placeholder"
+msgstr ""
+
+#. Default: "Search results"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_results"
+msgstr ""
+
+#. Default: "SITE"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_label"
+msgstr ""
+
+#. Default: "Site navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_navigation"
+msgstr ""
+
+#. Default: "Switch workspace"
+#: components/NavigationTree/messages
+msgid "navigation_tree_workspace_switcher_label"
+msgstr ""
 
 #. Default: "Next Review on:"
 #: components/ContentReviewSidebar/PostponeReview

--- a/frontend/packages/kitconcept-intranet/locales/volto.pot
+++ b/frontend/packages/kitconcept-intranet/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-06-11T08:48:13.948Z\n"
+"POT-Creation-Date: 2026-07-29T11:59:15.522Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -13,14 +13,59 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 "Domain: volto\n"
 
+#. Default: "AI Overview"
+#: components/Header/HeaderSearch
+msgid "AI Overview"
+msgstr ""
+
+#. Default: "AI-generated answer. It may contain errors."
+#: components/Header/HeaderSearch
+msgid "AI-generated answer. It may contain errors."
+msgstr ""
+
 #. Default: "Address"
 #: components/theme/PersonView
 msgid "Address"
 msgstr ""
 
+#. Default: "All"
+#: components/Header/HeaderSearch
+msgid "All"
+msgstr ""
+
+#. Default: "All statuses"
+#: components/Header/HeaderSearch
+msgid "All statuses"
+msgstr ""
+
+#. Default: "All types"
+#: components/Header/HeaderSearch
+msgid "All types"
+msgstr ""
+
+#. Default: "Any time"
+#: components/Header/HeaderSearch
+msgid "Any time"
+msgstr ""
+
+#. Default: "Ask AI"
+#: components/Header/HeaderSearch
+msgid "Ask AI"
+msgstr ""
+
+#. Default: "Ask a follow-up…"
+#: components/Header/HeaderSearch
+msgid "Ask a follow-up…"
+msgstr ""
+
 #. Default: "Assignee: *"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "Assignee"
+msgstr ""
+
+#. Default: "Beta"
+#: components/Header/HeaderSearch
+msgid "Beta"
 msgstr ""
 
 #. Default: "Bio"
@@ -67,6 +112,11 @@ msgstr ""
 msgid "Created On"
 msgstr ""
 
+#. Default: "Created by"
+#: components/Header/HeaderSearch
+msgid "Created by"
+msgstr ""
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -106,6 +156,11 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
+#. Default: "Event"
+#: components/Header/HeaderSearch
+msgid "Event"
+msgstr ""
+
 #. Default: "Expand sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Expand sidebar"
@@ -136,9 +191,24 @@ msgstr ""
 msgid "Feedback to:"
 msgstr ""
 
-#. Default: "Follow us:"
-#: components/Footer/slots/FollowUsLogoAndLinks
-msgid "Follow us:"
+#. Default: "File"
+#: components/Header/HeaderSearch
+msgid "File"
+msgstr ""
+
+#. Default: "Folder"
+#: components/Header/HeaderSearch
+msgid "Folder"
+msgstr ""
+
+#. Default: "Generating answer…"
+#: components/Header/HeaderSearch
+msgid "Generating answer…"
+msgstr ""
+
+#. Default: "Home"
+#: components/Header/HeaderBreadcrumbs
+msgid "Home"
 msgstr ""
 
 #. Default: "ICS Download"
@@ -146,9 +216,39 @@ msgstr ""
 msgid "ICS-Download"
 msgstr ""
 
+#. Default: "Image"
+#: components/Header/HeaderSearch
+msgid "Image"
+msgstr ""
+
+#. Default: "In review"
+#: components/Header/HeaderSearch
+msgid "In review"
+msgstr ""
+
+#. Default: "Intranet Portal"
+#: components/Header/HeaderSearch
+msgid "Intranet Portal"
+msgstr ""
+
 #. Default: "Invalid url"
 #: components/Blocks/IFrame/isValidUrl
 msgid "Invalid url"
+msgstr ""
+
+#. Default: "Last 3 months"
+#: components/Header/HeaderSearch
+msgid "Last 3 months"
+msgstr ""
+
+#. Default: "Last 30 days"
+#: components/Header/HeaderSearch
+msgid "Last 30 days"
+msgstr ""
+
+#. Default: "Last 7 days"
+#: components/Header/HeaderSearch
+msgid "Last 7 days"
 msgstr ""
 
 #. Default: "Last Modified On"
@@ -159,6 +259,11 @@ msgstr ""
 #. Default: "Last updated"
 #: components/Toolbar/DocumentReview
 msgid "Last updated"
+msgstr ""
+
+#. Default: "Last year"
+#: components/Header/HeaderSearch
+msgid "Last year"
 msgstr ""
 
 #. Default: "List with date"
@@ -186,9 +291,24 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+#. Default: "News Item"
+#: components/Header/HeaderSearch
+msgid "News Item"
+msgstr ""
+
 #. Default: "Next review"
 #: components/Toolbar/DocumentReview
 msgid "Next review"
+msgstr ""
+
+#. Default: "No answer — no matching documents found."
+#: components/Header/HeaderSearch
+msgid "No answer — no matching documents found."
+msgstr ""
+
+#. Default: "No results for “{term}”."
+#: components/Header/HeaderSearch
+msgid "No results for “{term}”."
 msgstr ""
 
 #. Default: "Only internal e-mail addresses are permitted."
@@ -199,6 +319,16 @@ msgstr ""
 #. Default: "Organisational Unit"
 #: index
 msgid "Organisational Unit"
+msgstr ""
+
+#. Default: "Page"
+#: components/Header/HeaderSearch
+msgid "Page"
+msgstr ""
+
+#. Default: "Person"
+#: components/Header/HeaderSearch
+msgid "Person"
 msgstr ""
 
 #. Default: "Phone"
@@ -233,6 +363,16 @@ msgstr ""
 msgid "PostponeTitle"
 msgstr ""
 
+#. Default: "Private"
+#: components/Header/HeaderSearch
+msgid "Private"
+msgstr ""
+
+#. Default: "Published"
+#: components/Header/HeaderSearch
+msgid "Published"
+msgstr ""
+
 #. Default: "Responsibilities"
 #: index
 msgid "Responsibilities"
@@ -248,6 +388,26 @@ msgstr ""
 #: components/Summary/PersonSummary
 #: components/theme/PersonView
 msgid "Room"
+msgstr ""
+
+#. Default: "Search"
+#: components/Header/HeaderSearch
+msgid "Search"
+msgstr ""
+
+#. Default: "Search titles only"
+#: components/Header/HeaderSearch
+msgid "Search titles only"
+msgstr ""
+
+#. Default: "Search workspace"
+#: components/Header/HeaderSearch
+msgid "Search workspace"
+msgstr ""
+
+#. Default: "Search…"
+#: components/Header/HeaderSearch
+msgid "Search…"
 msgstr ""
 
 #. Default: "Please Select ..."
@@ -270,6 +430,16 @@ msgstr ""
 msgid "Share this page via email"
 msgstr ""
 
+#. Default: "Show archived content"
+#: components/Header/HeaderSearch
+msgid "Show archived content"
+msgstr ""
+
+#. Default: "Show more breadcrumb items"
+#: components/Header/HeaderBreadcrumbs
+msgid "Show more breadcrumb items"
+msgstr ""
+
 #. Default: "Shrink sidebar"
 #: components/ContentReviewSidebar/ReviewSidebar
 msgid "Shrink sidebar"
@@ -278,6 +448,11 @@ msgstr ""
 #. Default: "Site"
 #: components/theme/PersonView
 msgid "Site"
+msgstr ""
+
+#. Default: "Site Setup"
+#: components/Header/useHeaderBreadcrumbs
+msgid "Site Setup"
 msgstr ""
 
 #. Default: "Something went wrong while liking this post."
@@ -290,6 +465,11 @@ msgstr ""
 msgid "Something went wrong while unliking this post."
 msgstr ""
 
+#. Default: "Sources"
+#: components/Header/HeaderSearch
+msgid "Sources"
+msgstr ""
+
 #. Default: "Sponsored by:"
 #: components/Footer/slots/FollowUsLogoAndLinks
 msgid "Sponsored by:"
@@ -298,6 +478,16 @@ msgstr ""
 #. Default: "Start"
 #: components/Blocks/EventMetadata/View
 msgid "Start"
+msgstr ""
+
+#. Default: "Start typing to search…"
+#: components/Header/HeaderSearch
+msgid "Start typing to search…"
+msgstr ""
+
+#. Default: "Status"
+#: components/Header/HeaderSearch
+msgid "Status"
 msgstr ""
 
 #. Default: "Subject page/URL"
@@ -313,6 +503,11 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
+#. Default: "The AI answer is currently unavailable. Please try again."
+#: components/Header/HeaderSearch
+msgid "The AI answer is currently unavailable. Please try again."
+msgstr ""
+
 #. Default: "The displayed content is tailored to your organizational unit and location."
 #: slots/ListingDisclaimer/ListingDisclaimer
 msgid "The displayed content is tailored to your organizational unit and location."
@@ -323,6 +518,21 @@ msgstr ""
 msgid "To submit a Like you must be logged in"
 msgstr ""
 
+#. Default: "Today"
+#: components/Header/HeaderSearch
+msgid "Today"
+msgstr ""
+
+#. Default: "Type"
+#: components/Header/HeaderSearch
+msgid "Type"
+msgstr ""
+
+#. Default: "Updated"
+#: components/Header/HeaderSearch
+msgid "Updated"
+msgstr ""
+
 #. Default: "Use preset review interval"
 #: components/ContentReviewSidebar/PostponeReview
 msgid "Use preset review interval"
@@ -331,6 +541,11 @@ msgstr ""
 #. Default: "Website"
 #: components/Blocks/EventMetadata/View
 msgid "Website"
+msgstr ""
+
+#. Default: "Workspace"
+#: components/Header/HeaderSearch
+msgid "Workspace"
 msgstr ""
 
 #. Default: "Your feedback has been submitted successfully. You will receive a confirmation email shortly."
@@ -371,6 +586,106 @@ msgstr ""
 #. Default: "last modified"
 #: slots/DocumentByLine/DocumentByLine
 msgid "modified"
+msgstr ""
+
+#. Default: "Something went wrong"
+#: components/NavigationTree/messages
+msgid "navigation_tree_action_error"
+msgstr ""
+
+#. Default: "Add new"
+#: components/NavigationTree/messages
+msgid "navigation_tree_add_new"
+msgstr ""
+
+#. Default: "Clear search"
+#: components/NavigationTree/messages
+msgid "navigation_tree_clear_search"
+msgstr ""
+
+#. Default: "Close navigation tree"
+#: components/NavigationTree/messages
+msgid "navigation_tree_close_panel"
+msgstr ""
+
+#. Default: "Delete"
+#: components/NavigationTree/messages
+msgid "navigation_tree_delete"
+msgstr ""
+
+#. Default: "Duplicate"
+#: components/NavigationTree/messages
+msgid "navigation_tree_duplicate"
+msgstr ""
+
+#. Default: "Loading…"
+#: components/NavigationTree/messages
+msgid "navigation_tree_loading"
+msgstr ""
+
+#. Default: "More actions"
+#: components/NavigationTree/messages
+msgid "navigation_tree_more_actions"
+msgstr ""
+
+#. Default: "NAVIGATION"
+#: components/NavigationTree/messages
+msgid "navigation_tree_navigation_label"
+msgstr ""
+
+#. Default: "No results found"
+#: components/NavigationTree/messages
+msgid "navigation_tree_no_results"
+msgstr ""
+
+#. Default: "Open navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_open_navigation"
+msgstr ""
+
+#. Default: "Rename"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename"
+msgstr ""
+
+#. Default: "Title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_rename_title_label"
+msgstr ""
+
+#. Default: "Resize navigation panel"
+#: components/NavigationTree/messages
+msgid "navigation_tree_resize_panel"
+msgstr ""
+
+#. Default: "Search navigation by title"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_aria_label"
+msgstr ""
+
+#. Default: "Search by title..."
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_placeholder"
+msgstr ""
+
+#. Default: "Search results"
+#: components/NavigationTree/messages
+msgid "navigation_tree_search_results"
+msgstr ""
+
+#. Default: "SITE"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_label"
+msgstr ""
+
+#. Default: "Site navigation"
+#: components/NavigationTree/messages
+msgid "navigation_tree_site_navigation"
+msgstr ""
+
+#. Default: "Switch workspace"
+#: components/NavigationTree/messages
+msgid "navigation_tree_workspace_switcher_label"
 msgstr ""
 
 #. Default: "Next Review on:"

--- a/frontend/packages/kitconcept-intranet/news/+ai-search-dialog.feature
+++ b/frontend/packages/kitconcept-intranet/news/+ai-search-dialog.feature
@@ -1,0 +1,2 @@
+Workspace search dialog per the approved design (internal ticket #426): live search results while typing (kitconcept.solr @solr-suggest), "Ask AI" button with the AI Overview answer panel and sources (@rag-search), Cmd+K/Ctrl+K shortcut, filter chips (visual, deferred backend). @reebalazs
+AI errors surface as a friendly localized message instead of the raw backend error (raw messages like embed timeouts under concurrent LLM load are logged to the console only, see internal ticket #515).

--- a/frontend/packages/kitconcept-intranet/src/components/Header/HeaderSearch.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/Header/HeaderSearch.tsx
@@ -1,15 +1,603 @@
-import { type FormEvent, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { defineMessages, useIntl } from 'react-intl';
 import { Button, Dialog, Modal, ModalOverlay } from 'react-aria-components';
+import { Menu, MenuItem, MenuTrigger } from '@plone/components';
+import { ChevrondownIcon } from '@plone/components/Icons';
 
 import Icon from '@plone/volto/components/theme/Icon/Icon';
+import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
 import zoomSVG from '@plone/volto/icons/zoom.svg';
+import calendarSVG from '@plone/volto/icons/calendar.svg';
+import fileSVG from '@plone/volto/icons/file.svg';
+import folderSVG from '@plone/volto/icons/folder.svg';
+import imageSVG from '@plone/volto/icons/image.svg';
+import linkSVG from '@plone/volto/icons/link.svg';
+import newsSVG from '@plone/volto/icons/news.svg';
+import pageSVG from '@plone/volto/icons/page.svg';
+import userSVG from '@plone/volto/icons/user.svg';
+import {
+  ragSearch,
+  resetRagSearch,
+  solrSearchSuggestions,
+} from '@kitconcept/volto-solr/actions';
+
+const messages = defineMessages({
+  searchWorkspace: {
+    id: 'Search workspace',
+    defaultMessage: 'Search workspace',
+  },
+  searchPlaceholder: {
+    id: 'Search…',
+    defaultMessage: 'Search…',
+  },
+  search: {
+    id: 'Search',
+    defaultMessage: 'Search',
+  },
+  typeToSearch: {
+    id: 'Start typing to search…',
+    defaultMessage: 'Start typing to search…',
+  },
+  noResultsFor: {
+    id: 'No results for “{term}”.',
+    defaultMessage: 'No results for “{term}”.',
+  },
+  askAI: {
+    id: 'Ask AI',
+    defaultMessage: 'Ask AI',
+  },
+  aiOverview: {
+    id: 'AI Overview',
+    defaultMessage: 'AI Overview',
+  },
+  aiBeta: {
+    id: 'Beta',
+    defaultMessage: 'Beta',
+  },
+  aiLoading: {
+    id: 'Generating answer…',
+    defaultMessage: 'Generating answer…',
+  },
+  aiNoAnswer: {
+    id: 'No answer — no matching documents found.',
+    defaultMessage: 'No answer — no matching documents found.',
+  },
+  aiError: {
+    id: 'The AI answer is currently unavailable. Please try again.',
+    defaultMessage: 'The AI answer is currently unavailable. Please try again.',
+  },
+  aiSources: {
+    id: 'Sources',
+    defaultMessage: 'Sources',
+  },
+  aiFollowUp: {
+    id: 'Ask a follow-up…',
+    defaultMessage: 'Ask a follow-up…',
+  },
+  aiDisclaimer: {
+    id: 'AI-generated answer. It may contain errors.',
+    defaultMessage: 'AI-generated answer. It may contain errors.',
+  },
+  filterWorkspace: {
+    id: 'Workspace',
+    defaultMessage: 'Workspace',
+  },
+  filterType: {
+    id: 'Type',
+    defaultMessage: 'Type',
+  },
+  filterCreator: {
+    id: 'Created by',
+    defaultMessage: 'Created by',
+  },
+  filterUpdated: {
+    id: 'Updated',
+    defaultMessage: 'Updated',
+  },
+  filterStatus: {
+    id: 'Status',
+    defaultMessage: 'Status',
+  },
+  intranetPortal: {
+    id: 'Intranet Portal',
+    defaultMessage: 'Intranet Portal',
+  },
+  allTypes: {
+    id: 'All types',
+    defaultMessage: 'All types',
+  },
+  typePage: {
+    id: 'Page',
+    defaultMessage: 'Page',
+  },
+  typeNews: {
+    id: 'News Item',
+    defaultMessage: 'News Item',
+  },
+  typeFolder: {
+    id: 'Folder',
+    defaultMessage: 'Folder',
+  },
+  typeFile: {
+    id: 'File',
+    defaultMessage: 'File',
+  },
+  typeImage: {
+    id: 'Image',
+    defaultMessage: 'Image',
+  },
+  typeEvent: {
+    id: 'Event',
+    defaultMessage: 'Event',
+  },
+  typePerson: {
+    id: 'Person',
+    defaultMessage: 'Person',
+  },
+  creatorAll: {
+    id: 'All',
+    defaultMessage: 'All',
+  },
+  anyTime: {
+    id: 'Any time',
+    defaultMessage: 'Any time',
+  },
+  today: {
+    id: 'Today',
+    defaultMessage: 'Today',
+  },
+  last7Days: {
+    id: 'Last 7 days',
+    defaultMessage: 'Last 7 days',
+  },
+  last30Days: {
+    id: 'Last 30 days',
+    defaultMessage: 'Last 30 days',
+  },
+  last3Months: {
+    id: 'Last 3 months',
+    defaultMessage: 'Last 3 months',
+  },
+  lastYear: {
+    id: 'Last year',
+    defaultMessage: 'Last year',
+  },
+  allStatuses: {
+    id: 'All statuses',
+    defaultMessage: 'All statuses',
+  },
+  statusPublished: {
+    id: 'Published',
+    defaultMessage: 'Published',
+  },
+  statusInReview: {
+    id: 'In review',
+    defaultMessage: 'In review',
+  },
+  statusPrivate: {
+    id: 'Private',
+    defaultMessage: 'Private',
+  },
+  chipTitleOnly: {
+    id: 'Search titles only',
+    defaultMessage: 'Search titles only',
+  },
+  chipArchived: {
+    id: 'Show archived content',
+    defaultMessage: 'Show archived content',
+  },
+});
+
+const typeIcons: Record<string, string> = {
+  Folder: folderSVG,
+  Document: pageSVG,
+  'News Item': newsSVG,
+  Event: calendarSVG,
+  File: fileSVG,
+  Image: imageSVG,
+  Link: linkSVG,
+  Person: userSVG,
+  Member: userSVG,
+};
+
+type SuggestionItem = {
+  '@id': string;
+  '@type': string;
+  title: string;
+  effective?: string | null;
+};
+
+const SparkleIcon = () => (
+  <svg
+    className="header-search-sparkle"
+    viewBox="0 0 24 24"
+    width="15"
+    height="15"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path
+      fill="currentColor"
+      d="M12 2l2.09 5.66L20 9.75l-5.91 2.09L12 17.5l-2.09-5.66L4 9.75l5.91-2.09L12 2zm7 11l1.19 3.22L23.5 17.4l-3.31 1.18L19 21.8l-1.19-3.22-3.31-1.18 3.31-1.18L19 13z"
+    />
+  </svg>
+);
+
+// The filter chips mirror the approved design (ticket #426). The
+// dropdowns open and remember a selection so they look and feel real,
+// but they do not filter the results: the backing facets are not
+// available on the backend yet, deferring them was accepted for the
+// demo scope. The option lists are static demo data from the design.
+const FilterChip = ({
+  label,
+  options,
+  selected,
+  onSelect,
+  isActive,
+}: {
+  label: string;
+  options: string[];
+  selected: string;
+  onSelect: (value: string) => void;
+  isActive: boolean;
+}) => (
+  <MenuTrigger>
+    <Button
+      className={`header-search-chip${isActive ? ' is-active' : ''}`}
+      type="button"
+    >
+      {label}: {selected}
+      <ChevrondownIcon aria-hidden="true" size="xs" />
+    </Button>
+    <Menu
+      className="header-search-chip-menu"
+      aria-label={label}
+      onAction={(key) => onSelect(String(key))}
+    >
+      {options.map((option) => (
+        <MenuItem key={option} id={option}>
+          {option}
+        </MenuItem>
+      ))}
+    </Menu>
+  </MenuTrigger>
+);
+
+const FilterChips = ({ workspaceTitle }: { workspaceTitle: string }) => {
+  const intl = useIntl();
+  const filters: Array<{
+    id: string;
+    label: string;
+    options: string[];
+  }> = [
+    {
+      id: 'workspace',
+      label: intl.formatMessage(messages.filterWorkspace),
+      options: [workspaceTitle, intl.formatMessage(messages.intranetPortal)],
+    },
+    {
+      id: 'type',
+      label: intl.formatMessage(messages.filterType),
+      options: [
+        intl.formatMessage(messages.allTypes),
+        intl.formatMessage(messages.typePage),
+        intl.formatMessage(messages.typeNews),
+        intl.formatMessage(messages.typeFolder),
+        intl.formatMessage(messages.typeFile),
+        intl.formatMessage(messages.typeImage),
+        intl.formatMessage(messages.typeEvent),
+        intl.formatMessage(messages.typePerson),
+      ],
+    },
+    {
+      id: 'creator',
+      label: intl.formatMessage(messages.filterCreator),
+      options: [
+        intl.formatMessage(messages.creatorAll),
+        'Dr. Sascha Köhler',
+        'Markus Thaler',
+        'Eva Lemke',
+        'Lukas Brandt',
+        'Julia Wagner',
+      ],
+    },
+    {
+      id: 'updated',
+      label: intl.formatMessage(messages.filterUpdated),
+      options: [
+        intl.formatMessage(messages.anyTime),
+        intl.formatMessage(messages.today),
+        intl.formatMessage(messages.last7Days),
+        intl.formatMessage(messages.last30Days),
+        intl.formatMessage(messages.last3Months),
+        intl.formatMessage(messages.lastYear),
+      ],
+    },
+    {
+      id: 'status',
+      label: intl.formatMessage(messages.filterStatus),
+      options: [
+        intl.formatMessage(messages.allStatuses),
+        intl.formatMessage(messages.statusPublished),
+        intl.formatMessage(messages.statusInReview),
+        intl.formatMessage(messages.statusPrivate),
+      ],
+    },
+  ];
+  const [selection, setSelection] = useState<Record<string, string>>({});
+  const [toggles, setToggles] = useState<Record<string, boolean>>({});
+  const toggleLabels: Array<{ id: string; label: string }> = [
+    { id: 'titleOnly', label: intl.formatMessage(messages.chipTitleOnly) },
+    { id: 'archived', label: intl.formatMessage(messages.chipArchived) },
+  ];
+  return (
+    <div className="header-search-filters">
+      <div className="header-search-chips">
+        {filters.map((filter) => {
+          const selected = selection[filter.id] || filter.options[0];
+          return (
+            <FilterChip
+              key={filter.id}
+              label={filter.label}
+              options={filter.options}
+              selected={selected}
+              onSelect={(value) =>
+                setSelection((current) => ({ ...current, [filter.id]: value }))
+              }
+              isActive={
+                filter.id === 'workspace'
+                  ? selected === workspaceTitle
+                  : selected !== filter.options[0]
+              }
+            />
+          );
+        })}
+      </div>
+      <div className="header-search-chip-toggles">
+        {toggleLabels.map(({ id, label }) => (
+          <button
+            key={id}
+            type="button"
+            className="header-search-chip-toggle"
+            aria-pressed={Boolean(toggles[id])}
+            onClick={() =>
+              setToggles((current) => ({ ...current, [id]: !current[id] }))
+            }
+          >
+            <span
+              className={`header-search-chip-checkbox${
+                toggles[id] ? ' is-checked' : ''
+              }`}
+            />
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const SuggestionRow = ({
+  item,
+  onSelect,
+}: {
+  item: SuggestionItem;
+  onSelect: (item: SuggestionItem) => void;
+}) => {
+  const intl = useIntl();
+  const effectiveDate =
+    item.effective && new Date(item.effective).getFullYear() > 1970
+      ? intl.formatDate(item.effective, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        })
+      : null;
+  return (
+    <button
+      type="button"
+      className="header-search-result"
+      onClick={() => onSelect(item)}
+    >
+      <Icon name={typeIcons[item['@type']] || pageSVG} size="21px" />
+      <span className="header-search-result-title">{item.title}</span>
+      {effectiveDate ? (
+        <span className="header-search-result-date">{effectiveDate}</span>
+      ) : null}
+    </button>
+  );
+};
+
+// The LLM answers use markdown inline emphasis (**bold**, *italic*).
+// Render just those instead of pulling in a markdown library: the
+// prompt asks for plain text, emphasis is all that shows up in
+// practice, and raw asterisks look broken in the answer panel.
+const emphasizeAnswer = (text: string) =>
+  text
+    .split(/(\*\*[^*]+\*\*|\*[^*\n]+\*)/g)
+    .filter(Boolean)
+    .map((part, index) => {
+      if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
+        return <strong key={index}>{part.slice(2, -2)}</strong>;
+      }
+      if (part.startsWith('*') && part.endsWith('*') && part.length > 2) {
+        return <em key={index}>{part.slice(1, -1)}</em>;
+      }
+      return part;
+    });
+
+type RagState = {
+  answer: string | null;
+  sources: Array<{ UID: string; '@id': string; title: string }>;
+  error: string | null;
+  loading: boolean;
+  loaded: boolean;
+};
+
+// Reveal the answer progressively ("AI is typing"): the backend
+// returns the full answer in one response, this is presentation only.
+// Sources and the follow-up field appear once the reveal is done.
+// Honors prefers-reduced-motion by showing the text at once.
+const TYPEWRITER_CHARS_PER_TICK = 3;
+const TYPEWRITER_TICK_MS = 15;
+
+const useTypewriter = (text: string | null) => {
+  const [position, setPosition] = useState(0);
+  const length = text?.length ?? 0;
+
+  useEffect(() => {
+    setPosition(0);
+    if (!length) {
+      return;
+    }
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      setPosition(length);
+      return;
+    }
+    const interval = window.setInterval(() => {
+      setPosition((current) => {
+        const next = current + TYPEWRITER_CHARS_PER_TICK;
+        if (next >= length) {
+          window.clearInterval(interval);
+          return length;
+        }
+        return next;
+      });
+    }, TYPEWRITER_TICK_MS);
+    return () => window.clearInterval(interval);
+  }, [text, length]);
+
+  return {
+    visibleText: text ? text.slice(0, position) : '',
+    done: position >= length,
+  };
+};
+
+const AiOverview = ({
+  rag,
+  onSelectSource,
+}: {
+  rag: RagState;
+  onSelectSource: (url: string) => void;
+}) => {
+  const intl = useIntl();
+  useEffect(() => {
+    if (rag.error) {
+      // eslint-disable-next-line no-console
+      console.warn('AI search error:', rag.error);
+    }
+  }, [rag.error]);
+  const typed = useTypewriter(rag.answer);
+  return (
+    <div className="header-search-ai">
+      <div className="header-search-ai-header">
+        <span className="header-search-ai-title">
+          <SparkleIcon />
+          {intl.formatMessage(messages.aiOverview)}
+        </span>
+        <span className="header-search-ai-beta">
+          {intl.formatMessage(messages.aiBeta)}
+        </span>
+      </div>
+      {rag.loading ? (
+        <p className="header-search-ai-loading">
+          {intl.formatMessage(messages.aiLoading)}
+        </p>
+      ) : null}
+      {/* Always show a friendly message instead of rag.error: the raw
+          backend message is technical (e.g. "timeout after 30.0s calling
+          /ollama/api/embed" when concurrent generations queue up on the
+          LLM server, see intranet ticket #515) and must not surface to
+          users. The technical detail goes to the console for debugging. */}
+      {rag.error ? (
+        <p className="header-search-ai-error">
+          {intl.formatMessage(messages.aiError)}
+        </p>
+      ) : null}
+      {rag.answer ? (
+        <p className="header-search-ai-answer">
+          {emphasizeAnswer(typed.visibleText)}
+        </p>
+      ) : null}
+      {rag.loaded && !rag.answer && !rag.error ? (
+        <p className="header-search-ai-answer">
+          {intl.formatMessage(messages.aiNoAnswer)}
+        </p>
+      ) : null}
+      {typed.done && (rag.sources || []).length > 0 ? (
+        <div className="header-search-ai-sources">
+          <span className="header-search-ai-sources-label">
+            {intl.formatMessage(messages.aiSources)}
+          </span>
+          {rag.sources.map((source) => (
+            <button
+              key={source.UID}
+              type="button"
+              className="header-search-ai-source"
+              onClick={() => onSelectSource(flattenToAppURL(source['@id']))}
+            >
+              <Icon name={pageSVG} size="16px" />
+              {source.title}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      {rag.loaded && typed.done ? (
+        <>
+          {/* Follow-up questions need a multi-turn backend (not in the
+              single-turn MVP): the field is part of the approved design
+              but stays inactive for now. */}
+          <div className="header-search-ai-followup">
+            <input
+              type="text"
+              disabled
+              placeholder={intl.formatMessage(messages.aiFollowUp)}
+            />
+            <span className="header-search-ai-followup-send" />
+          </div>
+          <p className="header-search-ai-disclaimer">
+            {intl.formatMessage(messages.aiDisclaimer)}
+          </p>
+        </>
+      ) : null}
+    </div>
+  );
+};
 
 const HeaderSearch = () => {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchText, setSearchText] = useState('');
+  const [aiAsked, setAiAsked] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const history = useHistory();
+  const dispatch = useDispatch();
+  const intl = useIntl();
+
+  const suggestions: SuggestionItem[] = useSelector(
+    (state: any) => state.solrSearchSuggestions?.items || [],
+  );
+  const rag: RagState = useSelector((state: any) => state.ragsearch || {});
+  const ragAvailable: boolean = useSelector(
+    (state: any) =>
+      state?.site?.data?.['kitconcept.solr.rag_available'] === true,
+  );
+  const workspaceTitle: string = useSelector(
+    (state: any) =>
+      state.content?.data?.['@components']?.inherit?.[
+        'kitconcept.plate.workspace'
+      ]?.from?.title || '…',
+  );
+
+  const term = searchText.trim();
+  const showResults = term.length >= 2;
 
   useEffect(() => {
     if (isSearchOpen) {
@@ -17,17 +605,88 @@ const HeaderSearch = () => {
     }
   }, [isSearchOpen]);
 
+  // Cmd+K / Ctrl+K opens the search dialog - but not from editable
+  // contexts: in editors the same shortcut means "insert link" (e.g.
+  // the Plate editor's floating link input), which must keep working.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        const target = event.target as HTMLElement | null;
+        if (
+          target &&
+          (target.isContentEditable ||
+            target.tagName === 'INPUT' ||
+            target.tagName === 'TEXTAREA')
+        ) {
+          return;
+        }
+        event.preventDefault();
+        setIsSearchOpen(true);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  // Live search: debounced suggestions for the current term.
+  useEffect(() => {
+    if (!isSearchOpen || term.length < 2) {
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      dispatch(solrSearchSuggestions(encodeURIComponent(term)));
+    }, 250);
+    return () => window.clearTimeout(timeout);
+  }, [dispatch, isSearchOpen, term]);
+
+  const resetAi = useCallback(() => {
+    setAiAsked(false);
+    dispatch(resetRagSearch());
+  }, [dispatch]);
+
+  const closeSearch = useCallback(() => {
+    setIsSearchOpen(false);
+    setSearchText('');
+    resetAi();
+  }, [resetAi]);
+
+  const onOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      setIsSearchOpen(true);
+    } else {
+      closeSearch();
+    }
+  };
+
+  const onChangeText = (text: string) => {
+    setSearchText(text);
+    if (aiAsked) {
+      resetAi();
+    }
+  };
+
+  const navigateTo = (url: string) => {
+    closeSearch();
+    history.push(url);
+  };
+
   const submitSearch = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-
-    const text = searchText.trim();
-
-    history.push(
-      text ? `/search?SearchableText=${encodeURIComponent(text)}` : '/search',
+    navigateTo(
+      term ? `/search?SearchableText=${encodeURIComponent(term)}` : '/search',
     );
+  };
 
-    setSearchText('');
-    setIsSearchOpen(false);
+  const onAskAI = () => {
+    if (!term || rag.loading) {
+      return;
+    }
+    // Clear the previous answer first: the reducer keeps the last
+    // result during a pending request, which would show the stale
+    // answer below the loading indicator.
+    dispatch(resetRagSearch());
+    setAiAsked(true);
+    dispatch(ragSearch('', term));
   };
 
   return (
@@ -35,24 +694,27 @@ const HeaderSearch = () => {
       <Button
         className="header-search-button"
         type="button"
-        aria-label="Search"
+        aria-label={intl.formatMessage(messages.searchWorkspace)}
         onPress={() => setIsSearchOpen(true)}
       >
         <Icon name={zoomSVG} size="24px" />
-        <span className="header-search-button-label">Search the site...</span>
+        <span className="header-search-button-label">
+          {intl.formatMessage(messages.searchWorkspace)}
+        </span>
+        <span className="header-search-button-kbd">⌘K</span>
       </Button>
 
       <ModalOverlay
         className="header-search-modal-backdrop"
         isDismissable
         isOpen={isSearchOpen}
-        onOpenChange={setIsSearchOpen}
+        onOpenChange={onOpenChange}
       >
         <Modal className="header-search-modal">
           <Dialog
             className="header-search-dialog"
             role="dialog"
-            aria-label="Search"
+            aria-label={intl.formatMessage(messages.search)}
           >
             <form onSubmit={submitSearch}>
               <div className="header-search-input-row">
@@ -61,14 +723,51 @@ const HeaderSearch = () => {
                   ref={searchInputRef}
                   type="search"
                   value={searchText}
-                  aria-label="Search"
-                  placeholder="Search..."
-                  onChange={(event) => setSearchText(event.target.value)}
+                  aria-label={intl.formatMessage(messages.search)}
+                  placeholder={intl.formatMessage(messages.searchPlaceholder)}
+                  onChange={(event) => onChangeText(event.target.value)}
                 />
+                {ragAvailable && term ? (
+                  <Button
+                    className="header-search-ask-ai"
+                    type="button"
+                    onPress={onAskAI}
+                  >
+                    <SparkleIcon />
+                    {intl.formatMessage(messages.askAI)}
+                  </Button>
+                ) : null}
               </div>
             </form>
 
-            <div className="header-search-empty">Start typing to search...</div>
+            <FilterChips workspaceTitle={workspaceTitle} />
+
+            {showResults ? (
+              <div className="header-search-results">
+                {aiAsked ? (
+                  <AiOverview rag={rag} onSelectSource={navigateTo} />
+                ) : null}
+                {suggestions.length > 0 ? (
+                  suggestions.map((item) => (
+                    <SuggestionRow
+                      key={item['@id']}
+                      item={item}
+                      onSelect={(selected) =>
+                        navigateTo(flattenToAppURL(selected['@id']))
+                      }
+                    />
+                  ))
+                ) : (
+                  <div className="header-search-no-results">
+                    {intl.formatMessage(messages.noResultsFor, { term })}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="header-search-empty">
+                {intl.formatMessage(messages.typeToSearch)}
+              </div>
+            )}
           </Dialog>
         </Modal>
       </ModalOverlay>

--- a/frontend/packages/kitconcept-intranet/src/customizations/@kitconcept/volto-solr/components/theme/SolrSearch/SolrSearch.jsx
+++ b/frontend/packages/kitconcept-intranet/src/customizations/@kitconcept/volto-solr/components/theme/SolrSearch/SolrSearch.jsx
@@ -1,11 +1,13 @@
 /**
  * OVERRIDE: SolrSearch.jsx
- * REASON: No "Use AI" toggle (team decision 2026-07-23): when the RAG
- * feature is available, the AI answer always renders above the classic
- * results. The final presentation (an "AI" tab and "AI on top" of the
- * All tab) will come from the kitconcept.solr tabs configuration; this
- * override is the interim behavior until that lands.
- * DATE: 2026-07-23
+ * REASON: No AI on the classic search page: the AI answer lives in the
+ * workspace search dialog only ("KI fragen" button, ticket #426). The
+ * page neither renders the AI area nor fires the @rag-search request -
+ * every AI request occupies a backend worker thread for the duration
+ * of the LLM call (see internal ticket #515), so pages outside the
+ * dialog must not trigger it. kitconcept.solr keeps its own "Use AI"
+ * toggle behavior; this override removes it for the intranet.
+ * DATE: 2026-07-29
  * DEVELOPER: @reebalazs
  *
  * Search component.
@@ -51,8 +53,6 @@ import {
   queryStateToParams,
 } from '@kitconcept/volto-solr/components/theme/SolrSearch/SearchQuery';
 import { VocabProvider } from '@kitconcept/volto-solr/components/theme/SolrSearch/vocabs/VocabContext';
-import { ragSearch, resetRagSearch } from '@kitconcept/volto-solr/actions';
-import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
 
 const messages = defineMessages({
   TypeSearchWords: {
@@ -215,8 +215,6 @@ class SolrSearch extends Component {
     batching: null,
     searchableText: null,
     path: null,
-    // RAG: TESTING
-    rag: {},
   };
 
   constructor(props) {
@@ -281,13 +279,8 @@ class SolrSearch extends Component {
    */
   doSearch = (params) => {
     this.setState({ searchwordInStatus: params.SearchableText || '' });
-    // When RAG is available (the @site endpoint reported the feature
-    // enabled and configured, known before the first render), the
-    // question additionally goes to the RAG endpoint: the AI answer
-    // always renders above the classic result list (no toggle).
-    if (this.props.ragAvailable && params.SearchableText) {
-      this.props.ragSearch('', params.SearchableText);
-    }
+    // No AI request from the search page: the AI answer is available
+    // in the workspace search dialog only (see OVERRIDE header).
     this.props.searchContent('', {
       ...params,
       sort_on: params.sort_on !== 'relevance' ? params.sort_on : '',
@@ -355,179 +348,141 @@ class SolrSearch extends Component {
       this.props.contentTypeSearchResultViews[contentType] ||
       this.props.contentTypeSearchResultDefaultView;
     return (
-      <Segment basic id="page-search" className="header-wrapper">
-        <Helmet title="Search" />
-        <Container>
-          {this.props.showSearchInput ? (
-            <div className="search-input">
-              <form className="ui form" onSubmit={this.onSubmit}>
-                <div className="field searchbox">
-                  <TranslatedInput
-                    ref={this.inputRef}
-                    placeholder={messages.TypeSearchWords}
-                    className="searchinput"
-                    value={this.state.searchword}
-                    onChange={(e) =>
-                      this.setState({ searchword: e.target.value })
-                    }
-                    onSubmit={this.onSubmit}
-                  />
-                  <Button onClick={this.onSubmit}>
-                    <FormattedMessage id="Search" defaultMessage="Search" />{' '}
-                  </Button>
-                </div>
-              </form>
-            </div>
-          ) : null}
-          {/* AI answer area: always shown above the classic results
-              when the backend reports the feature available (no
-              toggle - team decision 2026-07-23). An unconfigured site
-              shows the classic search, untouched. Interim styling; the
-              final presentation comes from the kitconcept.solr tabs
-              configuration ("AI" tab / "AI on top"). */}
-          {this.props.ragAvailable &&
-          (this.props.rag.loading || this.props.rag.loaded) ? (
-            <div className="rag-answer" style={{ margin: '1em 0' }}>
-              <div
-                style={{
-                  border: '1px solid #ccc',
-                  background: '#f8f8f8',
-                  padding: '1em',
-                  marginTop: '0.5em',
-                }}
-              >
-                {this.props.rag.loading ? <p>Thinking…</p> : null}
-                {this.props.rag.error ? (
-                  <p style={{ color: 'red' }}>{this.props.rag.error}</p>
-                ) : null}
-                {this.props.rag.answer ? (
-                  <p style={{ whiteSpace: 'pre-wrap' }}>
-                    {this.props.rag.answer}
-                  </p>
-                ) : null}
-                {this.props.rag.loaded &&
-                !this.props.rag.answer &&
-                !this.props.rag.error ? (
-                  <p>No answer — no matching documents found.</p>
-                ) : null}
-                {(this.props.rag.sources || []).length > 0 ? (
-                  <ul>
-                    {this.props.rag.sources.map((source) => (
-                      <li key={source.UID}>
-                        <a href={flattenToAppURL(source['@id'])}>
-                          {source.title}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                ) : null}
+      <>
+        <Segment basic id="page-search" className="header-wrapper">
+          <Helmet title="Search" />
+          <Container>
+            {this.props.showSearchInput ? (
+              <div className="search-input">
+                <form className="ui form" onSubmit={this.onSubmit}>
+                  <div className="field searchbox">
+                    <TranslatedInput
+                      ref={this.inputRef}
+                      placeholder={messages.TypeSearchWords}
+                      className="searchinput"
+                      value={this.state.searchword}
+                      onChange={(e) =>
+                        this.setState({ searchword: e.target.value })
+                      }
+                      onSubmit={this.onSubmit}
+                    />
+                    <Button onClick={this.onSubmit}>
+                      <FormattedMessage id="Search" defaultMessage="Search" />{' '}
+                    </Button>
+                  </div>
+                </form>
               </div>
-            </div>
-          ) : null}
-          {this.state.allowLocal &&
-          getPathPrefix(this.props.history.location) !== undefined ? (
-            <LocalCheckbox
-              onChange={(checked) => this.setLocal(checked)}
-              checked={this.state.local}
+            ) : null}
+            {this.state.allowLocal &&
+            getPathPrefix(this.props.history.location) !== undefined ? (
+              <LocalCheckbox
+                onChange={(checked) => this.setLocal(checked)}
+                checked={this.state.local}
+              />
+            ) : null}
+            <SearchResultInfo
+              searchableText={this.state.searchwordInStatus}
+              total={this.props.total}
             />
-          ) : null}
-          <SearchResultInfo
-            searchableText={this.state.searchwordInStatus}
-            total={this.props.total}
-          />
-          <SearchTabs
-            groupSelect={this.state.groupSelect}
-            setGroupSelect={(groupSelect) => this.setGroupSelect(groupSelect)}
-            facetGroups={this.props.facetGroups}
-          />
-          <VocabProvider>
-            <article id="content">
-              <header>
-                {this.props.total > 0 ? (
-                  <div className="sorting-bar">
-                    <SelectLayout
-                      layouts={this.props.layouts}
-                      value={this.state.layout}
-                      onChange={(value) => {
-                        this.setState({ layout: value });
-                      }}
-                    />
-                    <SelectSorting
-                      value={this.state.sortOn}
-                      onChange={(selectedOption, order) => {
-                        this.onSortChange(selectedOption, order);
-                      }}
-                    />
-                  </div>
-                ) : null}
-              </header>
-              <div className="searchContentWrapper">
-                <SearchConditions
-                  groupSelect={this.state.groupSelect}
-                  facetFields={this.props.facetFields}
-                  vocabularies={this.props.vocabularies}
-                  conditionTree={this.state.facetConditions}
-                  setConditionTree={this.setConditionTree}
-                />
-                <Dimmer active={this.props.loading} inverted>
-                  <Loader indeterminate size="small">
-                    <FormattedMessage id="loading" defaultMessage="Loading" />
-                  </Loader>
-                </Dimmer>
-                <section
-                  id="content-core"
-                  className={`layout-${this.state.layout}`}
-                >
-                  <div className="search-items">
-                    {this.props.items?.map((item, index) => (
-                      <div key={'' + index + '-' + item['@id']}>
-                        {createElement(resultTypeMapper(item['@type']), {
-                          key: item['@id'],
-                          item,
-                          layout: this.state.layout,
-                        })}
-                      </div>
-                    ))}
-                  </div>
-                  {this.props.batching &&
-                    this.props.total / settings.defaultPageSize > 1 && (
-                      <div className="search-footer">
-                        <Pagination
-                          activePage={this.state.currentPage}
-                          totalPages={Math.ceil(
-                            this.props.total / settings.defaultPageSize,
-                          )}
-                          onPageChange={this.handleQueryPaginationChange}
-                          firstItem={null}
-                          lastItem={null}
-                          prevItem={{
-                            content: (
-                              <Icon name={paginationLeftSVG} size="18px" />
-                            ),
-                            icon: true,
-                            'aria-disabled': !this.props.batching.prev,
-                            className: !this.props.batching.prev
-                              ? 'disabled'
-                              : null,
-                          }}
-                          nextItem={{
-                            content: (
-                              <Icon name={paginationRightSVG} size="18px" />
-                            ),
-                            icon: true,
-                            'aria-disabled': !this.props.batching.next,
-                            className: !this.props.batching.next
-                              ? 'disabled'
-                              : null,
-                          }}
-                        />
-                      </div>
-                    )}
-                </section>
-              </div>
-            </article>
-          </VocabProvider>
-        </Container>
+            <SearchTabs
+              groupSelect={this.state.groupSelect}
+              setGroupSelect={(groupSelect) => this.setGroupSelect(groupSelect)}
+              facetGroups={this.props.facetGroups}
+            />
+            <VocabProvider>
+              <article id="content">
+                <header>
+                  {this.props.total > 0 ? (
+                    <div className="sorting-bar">
+                      <SelectLayout
+                        layouts={this.props.layouts}
+                        value={this.state.layout}
+                        onChange={(value) => {
+                          this.setState({ layout: value });
+                        }}
+                      />
+                      <SelectSorting
+                        value={this.state.sortOn}
+                        onChange={(selectedOption, order) => {
+                          this.onSortChange(selectedOption, order);
+                        }}
+                      />
+                    </div>
+                  ) : null}
+                </header>
+                <div className="searchContentWrapper">
+                  <SearchConditions
+                    groupSelect={this.state.groupSelect}
+                    facetFields={this.props.facetFields}
+                    vocabularies={this.props.vocabularies}
+                    conditionTree={this.state.facetConditions}
+                    setConditionTree={this.setConditionTree}
+                  />
+                  <Dimmer active={this.props.loading} inverted>
+                    <Loader indeterminate size="small">
+                      <FormattedMessage id="loading" defaultMessage="Loading" />
+                    </Loader>
+                  </Dimmer>
+                  <section
+                    id="content-core"
+                    className={`layout-${this.state.layout}`}
+                  >
+                    <div className="search-items">
+                      {this.props.items?.map((item, index) => (
+                        <div key={'' + index + '-' + item['@id']}>
+                          {createElement(resultTypeMapper(item['@type']), {
+                            key: item['@id'],
+                            item,
+                            layout: this.state.layout,
+                          })}
+                        </div>
+                      ))}
+                    </div>
+                    {this.props.batching &&
+                      this.props.total / settings.defaultPageSize > 1 && (
+                        <div className="search-footer">
+                          <Pagination
+                            activePage={this.state.currentPage}
+                            totalPages={Math.ceil(
+                              this.props.total / settings.defaultPageSize,
+                            )}
+                            onPageChange={this.handleQueryPaginationChange}
+                            firstItem={null}
+                            lastItem={null}
+                            prevItem={{
+                              content: (
+                                <Icon name={paginationLeftSVG} size="18px" />
+                              ),
+                              icon: true,
+                              'aria-disabled': !this.props.batching.prev,
+                              className: !this.props.batching.prev
+                                ? 'disabled'
+                                : null,
+                            }}
+                            nextItem={{
+                              content: (
+                                <Icon name={paginationRightSVG} size="18px" />
+                              ),
+                              icon: true,
+                              'aria-disabled': !this.props.batching.next,
+                              className: !this.props.batching.next
+                                ? 'disabled'
+                                : null,
+                            }}
+                          />
+                        </div>
+                      )}
+                  </section>
+                </div>
+              </article>
+            </VocabProvider>
+          </Container>
+        </Segment>
+        {/* The Toolbar portal is a sibling of the Segment, not a child:
+            createPortal returns a ReactPortal, which renders fine but is
+            not recognized by the prop-types `node` checker, so Segment's
+            propTypes would warn about invalid children (kitconcept.solr
+            #97). */}
         {this.state.isClient &&
           createPortal(
             <Toolbar
@@ -537,7 +492,7 @@ class SolrSearch extends Component {
             />,
             document.getElementById('toolbar'),
           )}
-      </Segment>
+      </>
     );
   }
 }
@@ -612,10 +567,6 @@ export default compose(
         loaded,
         loading,
         batching,
-        // RAG: TESTING
-        rag: state.ragsearch || {},
-        ragAvailable:
-          state?.site?.data?.['kitconcept.solr.rag_available'] === true,
         intl: state.intl,
         pathname: props.history.location.pathname,
         contentTypeSearchResultViews: contentTypeSearchResultViewsWithDefault(
@@ -630,9 +581,6 @@ export default compose(
     (dispatch, { searchAction }) => ({
       searchContent: (...args) =>
         dispatch(searchActionWithDefault(searchAction)(...args)),
-      // RAG: TESTING
-      ragSearch: (...args) => dispatch(ragSearch(...args)),
-      resetRagSearch: () => dispatch(resetRagSearch()),
     }),
   ),
   asyncConnect([

--- a/frontend/packages/kitconcept-intranet/src/theme/header.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/header.scss
@@ -280,6 +280,389 @@ body:has(.header-intranet-compact) {
   text-align: center;
 }
 
+// Search dialog additions for the #426 prototype design: kbd hint,
+// "Ask AI" pill, filter chips, live results, AI overview panel.
+$search-blue: #007eb1;
+$search-border: #edf1f2;
+$search-grey: #878f93;
+$search-text: #252525;
+
+.header-search-dialog {
+  display: flex;
+  max-height: 74vh;
+  flex-direction: column;
+}
+
+// The theme's global :focus-visible ring (set with !important) draws a
+// box around the dialog input; the design is borderless (the caret
+// indicates focus).
+.header-search-dialog .header-search-input-row input:focus-visible {
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.header-search-button-kbd {
+  padding: 2px 6px;
+  border: 1px solid #e2e8ea;
+  border-radius: 4px;
+  margin-left: auto;
+  background: #fff;
+  color: $search-grey;
+  font-size: 11px;
+}
+
+.header-search-ask-ai {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  padding: 7px 13px;
+  border: 1px solid $search-border;
+  border-radius: 999px;
+  background: #fff;
+  color: $search-blue;
+  cursor: pointer;
+  font-size: 13.5px;
+  font-weight: 600;
+  gap: 7px;
+
+  &:hover,
+  &:focus {
+    background: rgba(0, 126, 177, 0.07);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $search-blue;
+    outline-offset: 2px;
+  }
+}
+
+.header-search-filters {
+  padding: 0 20px 14px;
+}
+
+.header-search-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.header-search-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 11px;
+  border: 1px solid $search-border;
+  border-radius: 999px;
+  background: #fff;
+  color: $search-text;
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  gap: 8px;
+
+  svg {
+    flex: 0 0 auto;
+    color: $search-grey;
+  }
+
+  &:hover,
+  &[data-hovered] {
+    border-color: #d3dadd;
+  }
+
+  &.is-active {
+    border-color: $search-blue;
+    background: rgba(0, 126, 177, 0.07);
+    color: $search-blue;
+
+    svg {
+      color: $search-blue;
+    }
+  }
+}
+
+.react-aria-Popover:has(.header-search-chip-menu) {
+  min-width: 180px;
+  border: 1px solid #e1e6e9;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+
+  &[data-placement='bottom'] {
+    margin-top: 6px;
+  }
+}
+
+.header-search-chip-menu {
+  padding: 6px;
+
+  .react-aria-MenuItem {
+    display: flex;
+    min-height: 34px;
+    align-items: center;
+    padding: 6px 12px;
+    border-radius: 6px;
+    margin: 0;
+    color: $search-text;
+    cursor: pointer;
+    font-size: 14px;
+
+    &[data-hovered],
+    &[data-focused] {
+      background: #eef1f3;
+    }
+
+    &:focus-visible {
+      box-shadow: none !important;
+      outline: none !important;
+    }
+  }
+}
+
+.header-search-chip-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 12px;
+  color: $search-grey;
+  font-size: 13.5px;
+  gap: 20px;
+}
+
+.header-search-chip-toggle {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  gap: 8px;
+}
+
+.header-search-chip-checkbox {
+  position: relative;
+  width: 16px;
+  height: 16px;
+  border: 1px solid #d3dadd;
+  border-radius: 4px;
+  background: #fff;
+
+  &.is-checked {
+    border-color: $search-blue;
+    background: $search-blue;
+
+    &::after {
+      position: absolute;
+      top: 1px;
+      left: 4px;
+      width: 5px;
+      height: 9px;
+      border: solid #fff;
+      border-width: 0 2px 2px 0;
+      content: '';
+      transform: rotate(45deg);
+    }
+  }
+}
+
+.header-search-results {
+  overflow: auto;
+  padding: 8px 0 12px;
+  border-top: 1px solid #edf0f2;
+}
+
+.header-search-result {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  padding: 11px 24px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  gap: 12px;
+  text-align: left;
+
+  &:hover,
+  &:focus {
+    background: #f5f8f9;
+  }
+
+  .icon {
+    flex: 0 0 auto;
+    fill: $search-grey;
+  }
+}
+
+.header-search-result-title {
+  overflow: hidden;
+  min-width: 0;
+  flex: 1 1 0;
+  color: $search-text;
+  font-size: 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.header-search-result-date {
+  flex: 0 0 auto;
+  color: $search-grey;
+  font-size: 13px;
+}
+
+.header-search-no-results {
+  padding: 40px 20px;
+  color: $search-grey;
+  text-align: center;
+}
+
+.header-search-ai {
+  padding: 18px 20px;
+  border: 1px solid $search-border;
+  border-radius: 8px;
+  margin: 10px 20px 14px;
+  background: #f7f9fa;
+}
+
+.header-search-ai-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+  gap: 10px;
+}
+
+.header-search-ai-title {
+  display: inline-flex;
+  align-items: center;
+  color: $search-blue;
+  font-size: 14px;
+  font-weight: 600;
+  gap: 7px;
+}
+
+.header-search-ai-beta {
+  padding: 0 5px;
+  border: 1px solid $search-border;
+  border-radius: 4px;
+  background: #fff;
+  color: $search-grey;
+  font-size: 11px;
+}
+
+.header-search-ai-loading {
+  margin: 0;
+  animation: header-search-ai-pulse 1.2s ease-in-out infinite;
+  color: $search-grey;
+}
+
+.header-search-ai-error {
+  margin: 0;
+  color: #b03434;
+}
+
+.header-search-ai-answer {
+  margin: 0;
+  color: $search-text;
+  font-size: 15px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.header-search-ai-sources {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 14px;
+  gap: 8px;
+}
+
+.header-search-ai-sources-label {
+  color: $search-grey;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.header-search-ai-source {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 11px;
+  border: 1px solid $search-border;
+  border-radius: 999px;
+  background: #fff;
+  color: $search-text;
+  cursor: pointer;
+  font-size: 13.5px;
+  gap: 7px;
+
+  &:hover,
+  &:focus {
+    border-color: $search-blue;
+    color: $search-blue;
+  }
+
+  .icon {
+    fill: $search-grey;
+  }
+
+  &:hover .icon,
+  &:focus .icon {
+    fill: $search-blue;
+  }
+}
+
+.header-search-ai-followup {
+  position: relative;
+  margin-top: 16px;
+
+  input {
+    width: 100%;
+    padding: 11px 48px 11px 16px;
+    border: 1px solid $search-border;
+    border-radius: 999px;
+    background: #fff;
+    color: $search-text;
+    font-size: 14px;
+
+    &::placeholder {
+      color: $search-grey;
+    }
+
+    &:disabled {
+      cursor: default;
+    }
+  }
+}
+
+.header-search-ai-followup-send {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #dfe5e8;
+  transform: translateY(-50%);
+}
+
+.header-search-ai-disclaimer {
+  margin: 10px 0 0;
+  color: $search-grey;
+  font-size: 12px;
+}
+
+@keyframes header-search-ai-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.45;
+  }
+}
+
 @keyframes pt-search-fade-in {
   from {
     opacity: 0;


### PR DESCRIPTION
Turns the workspace search popup into the approved dialog design (internal ticket #426).

## What it does

- **Livesearch**: results while typing via kitconcept.solr `@solr-suggest` (debounced), with type icons, dates, click-to-navigate.
- **KI fragen**: the AI Overview (KI-Überblick) panel on demand — Beta badge, grounded answer with typewriter reveal and markdown emphasis, source chips, inactive follow-up field (multi-turn backend pending) and the AI-generated disclaimer. Only rendered when the backend reports `kitconcept.solr.rag_available`. AI errors show a friendly localized message (technical detail in the console only).
- **Filter chips**: working-looking dropdowns with the option lists from the approved design; selections are remembered visually but do not filter — the backing facets (and the workspace scope switch) are deferred, accepted demo scope.
- **Search page** (override): the AI answer area and the `@rag-search` request are removed entirely — the AI lives in the workspace dialog only, so pages outside it never occupy a backend worker with an LLM call (internal ticket #515). Also fixes the Segment/Toolbar-portal prop-types warning (kitconcept.solr#97).
- **Cmd+K / Ctrl+K** opens the dialog; state resets on close. German translations for all new UI strings.

## Testing

Verified in the browser against a local demo workspace with real content: global livesearch results, AI answers with sources, typewriter reveal, chips/dropdowns, keyboard shortcut, dialog state resets. Lint/prettier/stylelint clean.

Internal tickets: #426 (design/scope), #515 (AI performance context).


## Deployment note

This PR also updates the `uv.lock` pin of `kitconcept-solr` to `397e09bc` (current `feature-ai-rag` tip). The previous pin was the **pre-hybrid** revision, so the currently deployed backend runs without the hybrid BM25+RRF retrieval (kitconcept.solr#92) and the latest fixes (#95, #98). Merging + redeploying this PR brings the deployment up to date in one step. No reindex required (the hybrid change is query-time; the index schema is unchanged).
