### PR TITLE
Update kitconcept-solr pin to the feature-ai-rag tip (#433)

### DIFF
--- a/backend/news/+solr-pin-update.internal
+++ b/backend/news/+solr-pin-update.internal
@@ -1,0 +1,1 @@
+Update the kitconcept-solr pin to the current feature-ai-rag tip: the lock still pinned the pre-hybrid revision, so deployments ran without the hybrid (BM25+RRF) retrieval and the latest fixes. @reebalazs

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.14.*"
 
 [options]
@@ -1589,7 +1589,7 @@ provides-extras = ["test"]
 [[package]]
 name = "kitconcept-solr"
 version = "2.0.0a14"
-source = { git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&branch=feature-ai-rag#7f5ba8c1c12ba60f3fdf40519e5ae0dc7363e9d5" }
+source = { git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&branch=feature-ai-rag#397e09bc498e8431850c7be8c221c000a89aadf9" }
 dependencies = [
     { name = "collective-solr" },
     { name = "plone-api" },


### PR DESCRIPTION
The `uv.lock` still pinned `kitconcept-solr` at `7f5ba8c1` — the **pre-hybrid** revision. That means the currently deployed backend runs **without** the hybrid BM25+RRF retrieval (kitconcept.solr#92) and without the recent fixes (kitconcept.solr#95, #98).

This bumps the pin to `397e09bc`, the current `feature-ai-rag` tip. The frontend needs no change — mrs.developer tracks the branch tip at build time.

cc @ericof — after merging, the io deployment needs a rebuild+redeploy to actually get the hybrid retrieval. No reindex required (the index schema is unchanged since the initial RAG deployment; the hybrid change is query-time).