### PR TITLE
Workspace search dialog: local/global scope switch (#426)

### DIFF
--- a/backend/news/+solr-pin-local-scope.internal
+++ b/backend/news/+solr-pin-local-scope.internal
@@ -1,0 +1,1 @@
+Update the kitconcept-solr pin to the feature-ai-rag tip with the local-scoping support (@solr-suggest path_prefix), required by the workspace-scope tests and the deployment. @reebalazs

--- a/backend/tests/services/search/test_solr_suggest.py
+++ b/backend/tests/services/search/test_solr_suggest.py
@@ -1,0 +1,63 @@
+"""@solr-suggest local (subtree) scoping via the path_prefix parameter.
+
+Mirrors the TestSuggestPathPrefix integration test in kitconcept.solr,
+exercised here through the intranet stack with the distribution's
+example content. The assertions are content-independent invariants:
+a scoped call returns exactly the global suggestions that live under
+the prefix, and a prefix without matches returns nothing.
+"""
+
+from urllib.parse import urlparse
+
+import pytest
+
+
+@pytest.fixture(scope="class")
+def answers():
+    return {
+        "site_id": "solr",
+        "title": "Intranet",
+        "description": "Site created with A Plone distribution for Intranets with Plone. Created by kitconcept.",  # noQA: E501
+        "workflow": "public",
+        "available_languages": ["en"],
+        "portal_timezone": "Europe/Berlin",
+        "setup_content": True,
+        "authentication": {"provider": "internal"},
+        "setup_solr": True,
+    }
+
+
+@pytest.fixture(scope="class")
+def portal(functional_portal):
+    yield functional_portal
+
+
+@pytest.mark.slow
+@pytest.mark.solr
+class TestSolrSuggestPathPrefix:
+    @pytest.fixture(autouse=True)
+    def _setup(self, portal, manager_request):
+        self.portal = portal
+        self.api_session = manager_request
+
+    def _suggest_paths(self, query: str, path_prefix: str | None = None):
+        url = f"/@solr-suggest?query={query}"
+        if path_prefix:
+            url += f"&path_prefix={path_prefix}"
+        response = self.api_session.get(url)
+        data = response.json()
+        return [urlparse(item["@id"]).path for item in data["suggestions"]]
+
+    def test_scoped_returns_the_subtree_subset_of_global(self):
+        paths = self._suggest_paths("standort")
+        assert len(paths) >= 1
+        # scope to the top-level folder of the first suggestion
+        top = "/" + paths[0].split("/")[2]
+        scoped = self._suggest_paths("standort", path_prefix=top)
+        expected = [p for p in paths if p.startswith(f"/solr{top}")]
+        assert scoped == expected
+        assert len(scoped) >= 1
+
+    def test_prefix_without_matches_returns_empty(self):
+        assert self._suggest_paths("standort") != []
+        assert self._suggest_paths("standort", path_prefix="/does-not-exist") == []

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1589,7 +1589,7 @@ provides-extras = ["test"]
 [[package]]
 name = "kitconcept-solr"
 version = "2.0.0a14"
-source = { git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&branch=feature-ai-rag#397e09bc498e8431850c7be8c221c000a89aadf9" }
+source = { git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&branch=feature-ai-rag#fcae6395075556a040c7b9972d1e4a8cbefdacc6" }
 dependencies = [
     { name = "collective-solr" },
     { name = "plone-api" },

--- a/frontend/cypress/tests/main/workspace-search-dialog.cy.js
+++ b/frontend/cypress/tests/main/workspace-search-dialog.cy.js
@@ -1,0 +1,97 @@
+// Tests for the workspace search dialog local/global scope switch
+// (ticket #426): inside a workspace the Workspace chip scopes the
+// livesearch and the Enter results page to the workspace subtree by
+// default; selecting "Intranet Portal" widens to a global search.
+//
+// The AI parts ("Ask AI") are not covered here: the acceptance backend
+// has no LLM configured, so rag_available is false and the button is
+// hidden by design (graceful degradation).
+//
+// The solr setup follows the style of search-persons.cy.js.
+
+context('Workspace search dialog (local/global scope)', () => {
+  beforeEach(() => {
+    // The solr connection parameters are provided by the COLLECTIVE_SOLR_*
+    // environment variables (docker compose setup) or by the registry
+    // defaults (local setup, solr listening on localhost:8983).
+    cy.setRegistry('collective.solr.active', true);
+    cy.reindexSolr();
+
+    cy.createContent({
+      contentType: 'Workspace',
+      contentId: 'greencat',
+      contentTitle: 'GreenCat Workspace',
+    });
+    cy.createContent({
+      contentType: 'WikiPage',
+      contentId: 'vacation-team-rules',
+      contentTitle: 'Vacation rules of the GreenCat team',
+      path: '/greencat',
+    });
+    // content outside the workspace, matching the same search term
+    cy.createContent({
+      contentType: 'Document',
+      contentId: 'vacation-form',
+      contentTitle: 'Vacation request form',
+      path: '/',
+    });
+
+    cy.autologin();
+  });
+  afterEach(() => {
+    cy.clearSolr();
+  });
+
+  it('scopes the livesearch to the workspace and can widen to global', () => {
+    cy.visit('/greencat');
+    cy.get('.header-search-button').click();
+    cy.get('.header-search-input-row input').type('vacation');
+
+    // workspace scope (default, chip active): only the workspace page
+    cy.get('.header-search-result-title').should('have.length', 1);
+    cy.get('.header-search-result-title').contains(
+      'Vacation rules of the GreenCat team',
+    );
+    cy.get('.header-search-chip.is-active').contains(
+      'Workspace: GreenCat Workspace',
+    );
+
+    // switch the Workspace chip to Intranet Portal -> global results
+    cy.get('.header-search-chip').contains('Workspace:').click();
+    cy.get('.header-search-chip-menu .react-aria-MenuItem')
+      .contains('Intranet Portal')
+      .click();
+    cy.get('.header-search-result-title').should('have.length.at.least', 2);
+    cy.get('.header-search-result-title').contains('Vacation request form');
+    cy.get('.header-search-chip').contains('Workspace: Intranet Portal');
+  });
+
+  it('Enter opens the workspace-scoped results page without a local toggle', () => {
+    cy.visit('/greencat');
+    cy.get('.header-search-button').click();
+    cy.get('.header-search-input-row input').type('vacation{enter}');
+
+    cy.url().should('include', '/greencat/@@search');
+    cy.url().should('include', 'local=true');
+
+    // only the workspace page in the classic results
+    cy.contains('Vacation rules of the GreenCat team');
+    cy.contains('Vacation request form').should('not.exist');
+    // the legacy local/global radio stays hidden (allow_local unset)
+    cy.get('.search-localized').should('not.exist');
+  });
+
+  it('Enter searches globally when Intranet Portal is selected', () => {
+    cy.visit('/greencat');
+    cy.get('.header-search-button').click();
+    cy.get('.header-search-input-row input').type('vacation');
+    cy.get('.header-search-chip').contains('Workspace:').click();
+    cy.get('.header-search-chip-menu .react-aria-MenuItem')
+      .contains('Intranet Portal')
+      .click();
+    cy.get('.header-search-input-row input').type('{enter}');
+
+    cy.url().should('include', '/search?SearchableText=vacation');
+    cy.contains('Vacation request form');
+  });
+});

--- a/frontend/packages/kitconcept-intranet/news/+ai-search-local-scope.feature
+++ b/frontend/packages/kitconcept-intranet/news/+ai-search-local-scope.feature
@@ -1,0 +1,1 @@
+Workspace search dialog: the Workspace chip is the local/global scope switch — workspace scope (default) restricts livesearch and the Enter results page to the workspace subtree, "Intranet Portal" searches globally. Covered by a Cypress test and a backend @solr-suggest path_prefix test; requires the kitconcept.solr local-scoping support. @reebalazs

--- a/frontend/packages/kitconcept-intranet/src/components/Header/HeaderSearch.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/Header/HeaderSearch.tsx
@@ -271,7 +271,17 @@ const FilterChip = ({
   </MenuTrigger>
 );
 
-const FilterChips = ({ workspaceTitle }: { workspaceTitle: string }) => {
+type SearchScope = 'workspace' | 'global';
+
+const FilterChips = ({
+  workspaceTitle,
+  scope,
+  onScopeChange,
+}: {
+  workspaceTitle: string;
+  scope: SearchScope;
+  onScopeChange: (scope: SearchScope) => void;
+}) => {
   const intl = useIntl();
   const filters: Array<{
     id: string;
@@ -342,7 +352,14 @@ const FilterChips = ({ workspaceTitle }: { workspaceTitle: string }) => {
     <div className="header-search-filters">
       <div className="header-search-chips">
         {filters.map((filter) => {
-          const selected = selection[filter.id] || filter.options[0];
+          // The Workspace chip is the real scope switch (local/global);
+          // the other chips are inert demo data (facets deferred).
+          const isScopeChip = filter.id === 'workspace';
+          const selected = isScopeChip
+            ? scope === 'workspace'
+              ? workspaceTitle
+              : intl.formatMessage(messages.intranetPortal)
+            : selection[filter.id] || filter.options[0];
           return (
             <FilterChip
               key={filter.id}
@@ -350,11 +367,18 @@ const FilterChips = ({ workspaceTitle }: { workspaceTitle: string }) => {
               options={filter.options}
               selected={selected}
               onSelect={(value) =>
-                setSelection((current) => ({ ...current, [filter.id]: value }))
+                isScopeChip
+                  ? onScopeChange(
+                      value === workspaceTitle ? 'workspace' : 'global',
+                    )
+                  : setSelection((current) => ({
+                      ...current,
+                      [filter.id]: value,
+                    }))
               }
               isActive={
-                filter.id === 'workspace'
-                  ? selected === workspaceTitle
+                isScopeChip
+                  ? scope === 'workspace'
                   : selected !== filter.options[0]
               }
             />
@@ -589,12 +613,28 @@ const HeaderSearch = () => {
     (state: any) =>
       state?.site?.data?.['kitconcept.solr.rag_available'] === true,
   );
-  const workspaceTitle: string = useSelector(
-    (state: any) =>
-      state.content?.data?.['@components']?.inherit?.[
-        'kitconcept.plate.workspace'
-      ]?.from?.title || '…',
+  const workspace: { title: string; path: string | null } = useSelector(
+    (state: any) => {
+      const from =
+        state.content?.data?.['@components']?.inherit?.[
+          'kitconcept.plate.workspace'
+        ]?.from;
+      return {
+        title: from?.title || '…',
+        path: from?.['@id'] ? flattenToAppURL(from['@id']) : null,
+      };
+    },
+    // Value based comparison: the selector builds a fresh object on
+    // every run, so reference equality would re-render on every store
+    // change.
+    (a: any, b: any) => a.title === b.title && a.path === b.path,
   );
+  // The Workspace chip switches the scope: workspace (default, local
+  // to the current workspace) or global ("Intranet Portal"). All three
+  // searches - livesearch, Ask AI and the Enter results page - follow
+  // it (see ticket #426 / kitconcept.solr local scoping).
+  const [scope, setScope] = useState<SearchScope>('workspace');
+  const scopePath = scope === 'workspace' ? workspace.path : null;
 
   const term = searchText.trim();
   const showResults = term.length >= 2;
@@ -634,10 +674,10 @@ const HeaderSearch = () => {
       return;
     }
     const timeout = window.setTimeout(() => {
-      dispatch(solrSearchSuggestions(encodeURIComponent(term)));
+      dispatch(solrSearchSuggestions(encodeURIComponent(term), scopePath));
     }, 250);
     return () => window.clearTimeout(timeout);
-  }, [dispatch, isSearchOpen, term]);
+  }, [dispatch, isSearchOpen, term, scopePath]);
 
   const resetAi = useCallback(() => {
     setAiAsked(false);
@@ -647,6 +687,7 @@ const HeaderSearch = () => {
   const closeSearch = useCallback(() => {
     setIsSearchOpen(false);
     setSearchText('');
+    setScope('workspace');
     resetAi();
   }, [resetAi]);
 
@@ -655,6 +696,14 @@ const HeaderSearch = () => {
       setIsSearchOpen(true);
     } else {
       closeSearch();
+    }
+  };
+
+  const onScopeChange = (nextScope: SearchScope) => {
+    setScope(nextScope);
+    if (aiAsked) {
+      // The AI answer was grounded in the previous scope.
+      resetAi();
     }
   };
 
@@ -672,9 +721,25 @@ const HeaderSearch = () => {
 
   const submitSearch = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    navigateTo(
-      term ? `/search?SearchableText=${encodeURIComponent(term)}` : '/search',
-    );
+    // Enter goes to the workspace-scoped search page: the nested
+    // @@search route plus local=true restricts the classic results
+    // (and, through the page's own wiring, the AI retrieval) to the
+    // workspace subtree. Without a workspace path, plain global search.
+    // is_multilingual=false: the intranet is monolingual, and the
+    // backend's multilingual path handling would neutralize the
+    // path_prefix filter on a site without plone.app.multilingual.
+    if (scopePath) {
+      const query = term
+        ? `?SearchableText=${encodeURIComponent(term)}&local=true` +
+          `&path_prefix=${encodeURIComponent(`${scopePath}/`)}` +
+          `&is_multilingual=false`
+        : '';
+      navigateTo(`${scopePath}/@@search${query}`);
+    } else {
+      navigateTo(
+        term ? `/search?SearchableText=${encodeURIComponent(term)}` : '/search',
+      );
+    }
   };
 
   const onAskAI = () => {
@@ -686,7 +751,7 @@ const HeaderSearch = () => {
     // answer below the loading indicator.
     dispatch(resetRagSearch());
     setAiAsked(true);
-    dispatch(ragSearch('', term));
+    dispatch(ragSearch('', term, scopePath || undefined));
   };
 
   return (
@@ -740,7 +805,11 @@ const HeaderSearch = () => {
               </div>
             </form>
 
-            <FilterChips workspaceTitle={workspaceTitle} />
+            <FilterChips
+              workspaceTitle={workspace.title}
+              scope={scope}
+              onScopeChange={onScopeChange}
+            />
 
             {showResults ? (
               <div className="header-search-results">

--- a/frontend/packages/kitconcept-intranet/src/customizations/@kitconcept/volto-solr/components/theme/SolrSearch/SolrSearch.jsx
+++ b/frontend/packages/kitconcept-intranet/src/customizations/@kitconcept/volto-solr/components/theme/SolrSearch/SolrSearch.jsx
@@ -285,10 +285,18 @@ class SolrSearch extends Component {
       ...params,
       sort_on: params.sort_on !== 'relevance' ? params.sort_on : '',
       b_start: (this.state.currentPage - 1) * config.settings.defaultPageSize,
-      path_prefix: getPathPrefix(window.location),
+      path_prefix: this.searchPathPrefix(params),
       doEmptySearch: this.props.doEmptySearch,
     });
   };
+
+  // An explicit path_prefix URL param wins over the URL heuristic:
+  // getPathPrefix treats every single-segment path as a language root
+  // (/de, /en), so a top-level subsite or workspace (/my-workspace)
+  // would silently lose its prefix. The workspace search dialog uses
+  // this for its workspace-scoped result pages.
+  searchPathPrefix = (params) =>
+    params.path_prefix || getPathPrefix(window.location);
 
   updateSearch = () => {
     this.props.history.replace({


### PR DESCRIPTION
Follow-up to #446: the Workspace chip becomes the real local/global scope control, as the design implies.

## What it does

- **Workspace scope (default, active chip styling)**: livesearch suggestions and the Enter results page are restricted to the workspace subtree; "Ask AI" retrieval follows the same scope, so answers are grounded only in workspace documents.
- **"Intranet Portal"**: searches globally (suggestions live-refresh on switch; Enter goes to the plain global `/search`).
- Enter in workspace scope navigates to the nested `<workspace>/@@search` page with `local=true`, an explicit `path_prefix` (the `getPathPrefix` heuristic treats single-segment paths as language roots and would drop top-level workspace prefixes) and `is_multilingual=false` (the multilingual path handling neutralizes the filter on this monolingual site). The legacy local/global checkbox stays hidden (`allow_local` deliberately unset).
- Switching scope resets a stale AI answer; scope resets to workspace when the dialog closes.

## Tests

- **Cypress** (`main` suite, solr-backed like `search-persons.cy.js`): scoped livesearch, chip widening to global, Enter to the scoped results page without a local toggle, global Enter under portal scope. The AI parts are intentionally untested — the acceptance backend has no LLM, `rag_available` is false and the button hidden by design.
- **Backend**: `@solr-suggest` `path_prefix` integration test through the intranet stack (content-independent invariants), mirroring kitconcept.solr's `TestSuggestPathPrefix`.

## Dependencies

Requires kitconcept.solr#103 (merged to `feature-ai-rag`): `@solr-suggest` `path_prefix` + action signatures. The `uv.lock` pin is bumped accordingly — deployment gets the suggest scoping with this PR.

Verified in the browser on the local dev stack: scoped/global livesearch, scoped AI answers with workspace-only sources, scoped results page.

Internal ticket: #426.