### PR TITLE
Restore the querystring widget depth field

### DIFF
--- a/frontend/packages/kitconcept-intranet/locales/de/LC_MESSAGES/volto.po
+++ b/frontend/packages/kitconcept-intranet/locales/de/LC_MESSAGES/volto.po
@@ -135,6 +135,11 @@ msgstr "Erstellt von"
 msgid "Created on"
 msgstr "Erstellt am"
 
+#. Default: "Criteria"
+#: components/widgets/QuerystringWidget
+msgid "Criteria"
+msgstr ""
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -144,6 +149,11 @@ msgstr "Prüfung/Anpassung delegieren"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "DelegateButton"
 msgstr "Delegieren"
+
+#. Default: "Depth"
+#: components/widgets/QuerystringWidget
+msgid "Depth"
+msgstr "Tiefe"
 
 #. Default: "Document Review"
 #: components/Toolbar/DocumentReview
@@ -259,6 +269,11 @@ msgstr "Ungültige URL"
 msgid "Is something unclear or outdated? Let us know so we can improve the page."
 msgstr "Etwas unklar oder veraltet? Lass es uns wissen, um die Seite zu verbessern."
 
+#. Default: "Item batch size"
+#: components/widgets/QuerystringWidget
+msgid "Item batch size"
+msgstr "Batch-Anzahl"
+
 #. Default: "Last 3 months"
 #: components/Header/HeaderSearch
 msgid "Last 3 months"
@@ -339,6 +354,16 @@ msgstr "Keine Antwort — keine passenden Dokumente gefunden."
 msgid "No results for “{term}”."
 msgstr "Keine Ergebnisse für „{term}“."
 
+#. Default: "No selection"
+#: components/widgets/QuerystringWidget
+msgid "No selection"
+msgstr "Keine Auswahl"
+
+#. Default: "Offset"
+#: components/widgets/QuerystringWidget
+msgid "Offset"
+msgstr "Offset"
+
 #. Default: "Only internal e-mail addresses are permitted."
 #: components/FeedBackForm/FeedBackForm
 msgid "Only internal e-mail addresses are permitted."
@@ -405,6 +430,16 @@ msgstr "Veröffentlicht"
 #: index
 msgid "Responsibilities"
 msgstr "Zuständigkeiten"
+
+#. Default: "Results limit"
+#: components/widgets/QuerystringWidget
+msgid "Results limit"
+msgstr "Anzahl der Ergebnisse einschränken"
+
+#. Default: "Reversed order"
+#: components/widgets/QuerystringWidget
+msgid "Reversed order"
+msgstr "Sortierreihenfolge umkehren"
 
 #. Default: "Review"
 #: components/ContentReviewSidebar/ReviewSidebar
@@ -493,6 +528,11 @@ msgstr "Beim Liken dieses Beitrags ist ein Fehler aufgetreten."
 #: components/ContentInteractions/ContentInteractions
 msgid "Something went wrong while unliking this post."
 msgstr "Beim Entliken dieses Beitrags ist ein Fehler aufgetreten."
+
+#. Default: "Sort on"
+#: components/widgets/QuerystringWidget
+msgid "Sort on"
+msgstr "Sortieren nach"
 
 #. Default: "Sources"
 #: components/Header/HeaderSearch

--- a/frontend/packages/kitconcept-intranet/locales/en/LC_MESSAGES/volto.po
+++ b/frontend/packages/kitconcept-intranet/locales/en/LC_MESSAGES/volto.po
@@ -135,6 +135,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#. Default: "Criteria"
+#: components/widgets/QuerystringWidget
+msgid "Criteria"
+msgstr ""
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -143,6 +148,11 @@ msgstr ""
 #. Default: "Delegate"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "DelegateButton"
+msgstr ""
+
+#. Default: "Depth"
+#: components/widgets/QuerystringWidget
+msgid "Depth"
 msgstr ""
 
 #. Default: "Document Review"
@@ -259,6 +269,11 @@ msgstr ""
 msgid "Is something unclear or outdated? Let us know so we can improve the page."
 msgstr ""
 
+#. Default: "Item batch size"
+#: components/widgets/QuerystringWidget
+msgid "Item batch size"
+msgstr ""
+
 #. Default: "Last 3 months"
 #: components/Header/HeaderSearch
 msgid "Last 3 months"
@@ -339,6 +354,16 @@ msgstr ""
 msgid "No results for “{term}”."
 msgstr ""
 
+#. Default: "No selection"
+#: components/widgets/QuerystringWidget
+msgid "No selection"
+msgstr ""
+
+#. Default: "Offset"
+#: components/widgets/QuerystringWidget
+msgid "Offset"
+msgstr ""
+
 #. Default: "Only internal e-mail addresses are permitted."
 #: components/FeedBackForm/FeedBackForm
 msgid "Only internal e-mail addresses are permitted."
@@ -404,6 +429,16 @@ msgstr ""
 #. Default: "Responsibilities"
 #: index
 msgid "Responsibilities"
+msgstr ""
+
+#. Default: "Results limit"
+#: components/widgets/QuerystringWidget
+msgid "Results limit"
+msgstr ""
+
+#. Default: "Reversed order"
+#: components/widgets/QuerystringWidget
+msgid "Reversed order"
 msgstr ""
 
 #. Default: "Review"
@@ -492,6 +527,11 @@ msgstr ""
 #. Default: "Something went wrong while unliking this post."
 #: components/ContentInteractions/ContentInteractions
 msgid "Something went wrong while unliking this post."
+msgstr ""
+
+#. Default: "Sort on"
+#: components/widgets/QuerystringWidget
+msgid "Sort on"
 msgstr ""
 
 #. Default: "Sources"

--- a/frontend/packages/kitconcept-intranet/locales/es/LC_MESSAGES/volto.po
+++ b/frontend/packages/kitconcept-intranet/locales/es/LC_MESSAGES/volto.po
@@ -142,6 +142,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#. Default: "Criteria"
+#: components/widgets/QuerystringWidget
+msgid "Criteria"
+msgstr ""
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -150,6 +155,11 @@ msgstr ""
 #. Default: "Delegate"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "DelegateButton"
+msgstr ""
+
+#. Default: "Depth"
+#: components/widgets/QuerystringWidget
+msgid "Depth"
 msgstr ""
 
 #. Default: "Document Review"
@@ -266,6 +276,11 @@ msgstr ""
 msgid "Is something unclear or outdated? Let us know so we can improve the page."
 msgstr ""
 
+#. Default: "Item batch size"
+#: components/widgets/QuerystringWidget
+msgid "Item batch size"
+msgstr ""
+
 #. Default: "Last 3 months"
 #: components/Header/HeaderSearch
 msgid "Last 3 months"
@@ -346,6 +361,16 @@ msgstr ""
 msgid "No results for “{term}”."
 msgstr ""
 
+#. Default: "No selection"
+#: components/widgets/QuerystringWidget
+msgid "No selection"
+msgstr ""
+
+#. Default: "Offset"
+#: components/widgets/QuerystringWidget
+msgid "Offset"
+msgstr ""
+
 #. Default: "Only internal e-mail addresses are permitted."
 #: components/FeedBackForm/FeedBackForm
 msgid "Only internal e-mail addresses are permitted."
@@ -411,6 +436,16 @@ msgstr ""
 #. Default: "Responsibilities"
 #: index
 msgid "Responsibilities"
+msgstr ""
+
+#. Default: "Results limit"
+#: components/widgets/QuerystringWidget
+msgid "Results limit"
+msgstr ""
+
+#. Default: "Reversed order"
+#: components/widgets/QuerystringWidget
+msgid "Reversed order"
 msgstr ""
 
 #. Default: "Review"
@@ -499,6 +534,11 @@ msgstr ""
 #. Default: "Something went wrong while unliking this post."
 #: components/ContentInteractions/ContentInteractions
 msgid "Something went wrong while unliking this post."
+msgstr ""
+
+#. Default: "Sort on"
+#: components/widgets/QuerystringWidget
+msgid "Sort on"
 msgstr ""
 
 #. Default: "Sources"

--- a/frontend/packages/kitconcept-intranet/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/frontend/packages/kitconcept-intranet/locales/pt_BR/LC_MESSAGES/volto.po
@@ -140,6 +140,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#. Default: "Criteria"
+#: components/widgets/QuerystringWidget
+msgid "Criteria"
+msgstr ""
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -148,6 +153,11 @@ msgstr ""
 #. Default: "Delegate"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "DelegateButton"
+msgstr ""
+
+#. Default: "Depth"
+#: components/widgets/QuerystringWidget
+msgid "Depth"
 msgstr ""
 
 #. Default: "Document Review"
@@ -264,6 +274,11 @@ msgstr "URL inválida"
 msgid "Is something unclear or outdated? Let us know so we can improve the page."
 msgstr ""
 
+#. Default: "Item batch size"
+#: components/widgets/QuerystringWidget
+msgid "Item batch size"
+msgstr ""
+
 #. Default: "Last 3 months"
 #: components/Header/HeaderSearch
 msgid "Last 3 months"
@@ -344,6 +359,16 @@ msgstr ""
 msgid "No results for “{term}”."
 msgstr ""
 
+#. Default: "No selection"
+#: components/widgets/QuerystringWidget
+msgid "No selection"
+msgstr ""
+
+#. Default: "Offset"
+#: components/widgets/QuerystringWidget
+msgid "Offset"
+msgstr ""
+
 #. Default: "Only internal e-mail addresses are permitted."
 #: components/FeedBackForm/FeedBackForm
 msgid "Only internal e-mail addresses are permitted."
@@ -410,6 +435,16 @@ msgstr ""
 #: index
 msgid "Responsibilities"
 msgstr "Responsabilidades"
+
+#. Default: "Results limit"
+#: components/widgets/QuerystringWidget
+msgid "Results limit"
+msgstr ""
+
+#. Default: "Reversed order"
+#: components/widgets/QuerystringWidget
+msgid "Reversed order"
+msgstr ""
 
 #. Default: "Review"
 #: components/ContentReviewSidebar/ReviewSidebar
@@ -498,6 +533,11 @@ msgstr "Algo deu errado ao curtir esta publicação."
 #: components/ContentInteractions/ContentInteractions
 msgid "Something went wrong while unliking this post."
 msgstr "Algo deu errado ao descurtir esta publicação."
+
+#. Default: "Sort on"
+#: components/widgets/QuerystringWidget
+msgid "Sort on"
+msgstr ""
 
 #. Default: "Sources"
 #: components/Header/HeaderSearch

--- a/frontend/packages/kitconcept-intranet/locales/volto.pot
+++ b/frontend/packages/kitconcept-intranet/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2026-07-30T13:29:35.811Z\n"
+"POT-Creation-Date: 2026-07-30T17:17:45.797Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -137,6 +137,11 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+#. Default: "Criteria"
+#: components/widgets/QuerystringWidget
+msgid "Criteria"
+msgstr ""
+
 #. Default: "Delegate Review Update"
 #: components/Toolbar/DocumentReview
 msgid "Delegate Review Update"
@@ -145,6 +150,11 @@ msgstr ""
 #. Default: "Delegate"
 #: components/ContentReviewSidebar/DelegateReview
 msgid "DelegateButton"
+msgstr ""
+
+#. Default: "Depth"
+#: components/widgets/QuerystringWidget
+msgid "Depth"
 msgstr ""
 
 #. Default: "Document Review"
@@ -261,6 +271,11 @@ msgstr ""
 msgid "Is something unclear or outdated? Let us know so we can improve the page."
 msgstr ""
 
+#. Default: "Item batch size"
+#: components/widgets/QuerystringWidget
+msgid "Item batch size"
+msgstr ""
+
 #. Default: "Last 3 months"
 #: components/Header/HeaderSearch
 msgid "Last 3 months"
@@ -341,6 +356,16 @@ msgstr ""
 msgid "No results for “{term}”."
 msgstr ""
 
+#. Default: "No selection"
+#: components/widgets/QuerystringWidget
+msgid "No selection"
+msgstr ""
+
+#. Default: "Offset"
+#: components/widgets/QuerystringWidget
+msgid "Offset"
+msgstr ""
+
 #. Default: "Only internal e-mail addresses are permitted."
 #: components/FeedBackForm/FeedBackForm
 msgid "Only internal e-mail addresses are permitted."
@@ -406,6 +431,16 @@ msgstr ""
 #. Default: "Responsibilities"
 #: index
 msgid "Responsibilities"
+msgstr ""
+
+#. Default: "Results limit"
+#: components/widgets/QuerystringWidget
+msgid "Results limit"
+msgstr ""
+
+#. Default: "Reversed order"
+#: components/widgets/QuerystringWidget
+msgid "Reversed order"
 msgstr ""
 
 #. Default: "Review"
@@ -494,6 +529,11 @@ msgstr ""
 #. Default: "Something went wrong while unliking this post."
 #: components/ContentInteractions/ContentInteractions
 msgid "Something went wrong while unliking this post."
+msgstr ""
+
+#. Default: "Sort on"
+#: components/widgets/QuerystringWidget
+msgid "Sort on"
 msgstr ""
 
 #. Default: "Sources"

--- a/frontend/packages/kitconcept-intranet/news/+restoreQuerystringDepthField.bugfix
+++ b/frontend/packages/kitconcept-intranet/news/+restoreQuerystringDepthField.bugfix
@@ -1,0 +1,1 @@
+Restore the top-level `Depth` field in the querystring widget when a path criterion is present, by overriding Volto's `QuerystringWidget` and reverting https://github.com/plone/volto/pull/8350. @ericof

--- a/frontend/packages/kitconcept-intranet/src/components/widgets/QuerystringWidget.jsx
+++ b/frontend/packages/kitconcept-intranet/src/components/widgets/QuerystringWidget.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import ObjectWidget from '@plone/volto/components/manage/Widgets/ObjectWidget';
+
+const messages = defineMessages({
+  Criteria: {
+    id: 'Criteria',
+    defaultMessage: 'Criteria',
+  },
+  depth: {
+    id: 'Depth',
+    defaultMessage: 'Depth',
+  },
+  SortOn: {
+    id: 'Sort on',
+    defaultMessage: 'Sort on',
+  },
+  reversedOrder: {
+    id: 'Reversed order',
+    defaultMessage: 'Reversed order',
+  },
+  limit: {
+    id: 'Results limit',
+    defaultMessage: 'Results limit',
+  },
+  offset: {
+    id: 'Offset',
+    defaultMessage: 'Offset',
+  },
+  itemBatchSize: {
+    id: 'Item batch size',
+    defaultMessage: 'Item batch size',
+  },
+  NoSelection: {
+    id: 'No selection',
+    defaultMessage: 'No selection',
+  },
+});
+
+export const objectSchema = ({ intl, isDisabled, value }) => ({
+  fieldsets: [
+    {
+      id: 'default',
+      title: 'Default',
+      fields: [
+        'query',
+        ...(value?.query?.filter((q) => q.i === 'path').length > 0
+          ? ['depth']
+          : []),
+        'sort_on',
+        'sort_order_boolean',
+        'limit',
+        'offset',
+        'b_size',
+      ],
+    },
+  ],
+  properties: {
+    query: {
+      title: intl.formatMessage(messages.Criteria),
+      widget: 'query',
+    },
+    depth: {
+      title: intl.formatMessage(messages.depth),
+      type: 'number',
+    },
+    sort_on: {
+      title: intl.formatMessage(messages.SortOn),
+      widget: 'query_sort_on',
+      isDisabled: isDisabled,
+    },
+    sort_order_boolean: {
+      title: intl.formatMessage(messages.reversedOrder),
+      type: 'boolean',
+      isDisabled: isDisabled,
+    },
+    limit: {
+      title: intl.formatMessage(messages.limit),
+      type: 'number',
+      isDisabled: isDisabled,
+    },
+    offset: {
+      title: intl.formatMessage(messages.offset),
+      type: 'number',
+      isDisabled: isDisabled,
+      default: 0,
+    },
+    b_size: {
+      title: intl.formatMessage(messages.itemBatchSize),
+      type: 'number',
+      isDisabled: isDisabled,
+    },
+  },
+  required: [],
+});
+
+const QuerystringWidget = (props) => {
+  const { block, onChange, schemaEnhancer } = props;
+  const isDisabled = props.value?.query?.length ? false : true;
+
+  const intl = useIntl();
+  let schema = objectSchema({ ...props, intl, isDisabled });
+  schema = schemaEnhancer ? schemaEnhancer({ ...props, intl, schema }) : schema;
+
+  return (
+    <div className="querystring-widget">
+      <ObjectWidget
+        {...props}
+        block={block}
+        schema={schema}
+        onChange={(id, value) => {
+          const adaptedValue = {
+            ...value,
+            sort_order: value.sort_order_boolean ? 'descending' : 'ascending',
+          };
+          onChange(id, adaptedValue);
+        }}
+      />
+    </div>
+  );
+};
+export default QuerystringWidget;

--- a/frontend/packages/kitconcept-intranet/src/customizations/volto/components/manage/Widgets/QuerystringWidget.jsx
+++ b/frontend/packages/kitconcept-intranet/src/customizations/volto/components/manage/Widgets/QuerystringWidget.jsx
@@ -1,0 +1,12 @@
+/**
+ * OVERRIDE: QuerystringWidget.jsx
+ * REASON: Revert PR https://github.com/plone/volto/pull/8350 of volto
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2026-07-30
+ * DEVELOPER: @ericof
+ * CHANGELOG:
+ *  - 2026-07-30 @ericof: Revert changes made by upstream PR
+ */
+import QuerystringWidget from '@kitconcept/intranet/components/widgets/QuerystringWidget';
+
+export default QuerystringWidget;


### PR DESCRIPTION
## Description

Restores the top-level `Depth` field in the querystring widget, reverting [plone/volto#8350](https://github.com/plone/volto/pull/8350) for the intranet.

Upstream 8350 removed the schema-level `depth` property and moved depth onto each path criterion instead, encoded as `uid::depth` in `QueryWidget`. This override brings the top-level field back, shown only when the query contains at least one `path` criterion.

## Implementation

- `src/components/widgets/QuerystringWidget.jsx` — the widget itself: Volto 19.3.0's `QuerystringWidget` plus the `depth` property and its conditional inclusion in the default fieldset.
- `src/customizations/volto/components/manage/Widgets/QuerystringWidget.jsx` — shadows `@plone/volto/components/manage/Widgets/QuerystringWidget` and re-exports the above.
- `locales/` — regenerated `.pot` and the four `.po` files; German strings filled in for the new messages.

## Notes for reviewers

- The per-path `uid::depth` encoding introduced by 8350 is still live in `QueryWidget`, so after this change both depth mechanisms exist side by side.
- The override re-exports only the default. Upstream's module also exports `objectSchema` (it is in Volto's `.d.ts`), so that named export is `undefined` while the shadow is active. Nothing in this repo imports it today.
- `Criteria` is the only new message left untranslated in `de`; core translates it as "Kriterium".

Refs https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/issues/541