### PR TITLE
Do not override solr-update-core-and-start in the compose and stack files

### DIFF
--- a/devops/stacks/demo.yml
+++ b/devops/stacks/demo.yml
@@ -99,9 +99,7 @@ services:
   solr:
     image: ghcr.io/kitconcept/solr:${SOLR_TAG:-feature-ai-rag}
     command:
-      - solr-precreate
-      - plone
-      - /plone-config
+      - solr-update-core-and-start
     environment:
       SOLR_MODULES: extraction
       SOLR_OPTS: "-Dsolr.tika.url=http://${STACK_NAME}-tika:9998"

--- a/devops/stacks/persistent.yml
+++ b/devops/stacks/persistent.yml
@@ -134,9 +134,7 @@ services:
   solr:
     image: ghcr.io/kitconcept/solr:${SOLR_TAG:-feature-ai-rag}
     command:
-      - solr-precreate
-      - plone
-      - /plone-config
+      - solr-update-core-and-start
     environment:
       SOLR_MODULES: extraction
       SOLR_OPTS: "-Dsolr.tika.url=http://${STACK_NAME}-tika:9998"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -57,9 +57,7 @@ x-solr: &solr
   ports:
     - 8983:8983
   command:
-    - solr-precreate
-    - plone
-    - /plone-config
+    - solr-update-core-and-start
   environment:
     SOLR_MODULES: extraction
 

--- a/news/+solr-update-core-not-overridden.internal
+++ b/news/+solr-update-core-not-overridden.internal
@@ -1,0 +1,1 @@
+Stop overriding the Solr image `CMD` with `solr-precreate`, so config updates reach an existing core (kitconcept/kitconcept.solr#107). @reekitconcept


### PR DESCRIPTION
Companion of kitconcept.solr#108 (merged): the compose and stack files overrode the image's `CMD` with `solr-precreate`, which silently disabled the `solr-update-core-and-start` script baked into the image — so core config changes shipped with a new image never reached an existing core. The script is now called explicitly in `command:`, so adding a `command:` back later cannot silently switch it off again.

Scope note: this PR now contains **only the command fix**. The by-revision pinning of the kitconcept.solr artifacts (backend, frontend, solr image) that used to be the second commit here has moved to #474, which pins to a newer revision that also carries the Plate RAG chunking fix (kitconcept.solr#112). Keeping the pinning in both PRs would only create conflicts between them.

Deployment note (unchanged, see comment below): deploying this recreates the solr container, and since the solr service has no volume the core comes up empty — a reindex is needed after the deploy. Proposal to decouple that: [#578](https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/work_items/578).