### PR TITLE
Pin kitconcept.solr to the Plate RAG fix revision (#580)

### DIFF
--- a/backend/news/+solr-rev-pin.bugfix
+++ b/backend/news/+solr-rev-pin.bugfix
@@ -1,0 +1,1 @@
+Pin kitconcept.solr to a revision instead of the branch: backend, frontend and the solr image. Includes the Plate RAG chunking fix (kitconcept.solr#112). @reebalazs

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -67,7 +67,7 @@ container = [
 
 [tool.uv.sources]
 kitconcept-plate = { path = "container/kitconcept-plate.tar.gz" }
-kitconcept-solr = { git = "https://github.com/kitconcept/kitconcept.solr.git", subdirectory = "backend", branch = "feature-ai-rag" }
+kitconcept-solr = { git = "https://github.com/kitconcept/kitconcept.solr.git", subdirectory = "backend", rev = "a8953cefb2d250bb83213bef0099ffceda87dc78" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1520,7 +1520,7 @@ requires-dist = [
     { name = "kitconcept-contactblock", specifier = "==1.0.0a6" },
     { name = "kitconcept-core", specifier = "==2.0.0b4" },
     { name = "kitconcept-plate", path = "container/kitconcept-plate.tar.gz" },
-    { name = "kitconcept-solr", git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&branch=feature-ai-rag" },
+    { name = "kitconcept-solr", git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&rev=a8953cefb2d250bb83213bef0099ffceda87dc78" },
     { name = "pas-plugins-authomatic", specifier = "==2.0.0" },
     { name = "pas-plugins-keycloakgroups", specifier = "==1.0.0b1" },
     { name = "pas-plugins-oidc", specifier = "==2.0.0" },
@@ -1589,7 +1589,7 @@ provides-extras = ["test"]
 [[package]]
 name = "kitconcept-solr"
 version = "2.0.0a14"
-source = { git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&branch=feature-ai-rag#fcae6395075556a040c7b9972d1e4a8cbefdacc6" }
+source = { git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&rev=a8953cefb2d250bb83213bef0099ffceda87dc78#a8953cefb2d250bb83213bef0099ffceda87dc78" }
 dependencies = [
     { name = "collective-solr" },
     { name = "plone-api" },

--- a/devops/stacks/demo.yml
+++ b/devops/stacks/demo.yml
@@ -97,7 +97,7 @@ services:
           - ${STACK_NAME}-tika
 
   solr:
-    image: ghcr.io/kitconcept/solr:${SOLR_TAG:-feature-ai-rag}
+    image: ghcr.io/kitconcept/solr:${SOLR_TAG:-sha-826383b}
     command:
       - solr-precreate
       - plone

--- a/devops/stacks/persistent.yml
+++ b/devops/stacks/persistent.yml
@@ -132,7 +132,7 @@ services:
           - ${STACK_NAME}-tika
 
   solr:
-    image: ghcr.io/kitconcept/solr:${SOLR_TAG:-feature-ai-rag}
+    image: ghcr.io/kitconcept/solr:${SOLR_TAG:-sha-826383b}
     command:
       - solr-precreate
       - plone

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -52,7 +52,7 @@ x-tika: &tika
     - 9998:9998
 
 x-solr: &solr
-  image: ghcr.io/kitconcept/solr:${SOLR_TAG:-feature-ai-rag}
+  image: ghcr.io/kitconcept/solr:${SOLR_TAG:-sha-826383b}
   platform: linux/amd64
   ports:
     - 8983:8983

--- a/frontend/mrs.developer.json
+++ b/frontend/mrs.developer.json
@@ -135,7 +135,7 @@
     "url": "git@github.com:kitconcept/kitconcept.solr.git",
     "https": "https://github.com/kitconcept/kitconcept.solr.git",
     "path": "frontend/packages/volto-solr",
-    "branch": "feature-ai-rag"
+    "tag": "a8953cefb2d250bb83213bef0099ffceda87dc78"
   },
   "volto-contact-block": {
     "develop": true,

--- a/frontend/packages/kitconcept-intranet/news/+solr-rev-pin.bugfix
+++ b/frontend/packages/kitconcept-intranet/news/+solr-rev-pin.bugfix
@@ -1,0 +1,1 @@
+Pin kitconcept.solr to a revision instead of the branch: backend, frontend and the solr image. Includes the Plate RAG chunking fix (kitconcept.solr#112). @reebalazs

--- a/news/+solr-rev-pin.bugfix
+++ b/news/+solr-rev-pin.bugfix
@@ -1,0 +1,1 @@
+Pin kitconcept.solr to a revision instead of the branch: backend, frontend and the solr image. Includes the Plate RAG chunking fix (kitconcept.solr#112). @reebalazs


### PR DESCRIPTION
Companion to kitconcept.solr [PR #113](https://github.com/kitconcept/kitconcept.solr/pull/113) — the fix for GitLab ticket [#580](https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/work_items/580) (WikiPage content authored in the Plate editor invisible to the RAG search: the `__somersault__` block is stored in `blocks` but not listed in `blocks_layout`, and the RAG extraction only walked the layout).

**Pins kitconcept.solr by revision instead of the branch, everywhere:**

- **backend**: `[tool.uv.sources]` uses `rev = a8953cef…` instead of `branch = "feature-ai-rag"` (+ `uv.lock` re-resolved) — this revision carries the #580 fix
- **frontend**: `mrs.developer.json` volto-solr uses `tag: a8953cef…` instead of `branch`
- **solr image**: default tag `sha-826383b` instead of the moving `feature-ai-rag` branch tag (content-identical: the `solr/` directory is unchanged since that revision)

Beyond delivering the fix for testing, this makes checkouts reproducible: what gets built no longer depends on when the branch tip was fetched.

**Purpose / process:** this branch is for @danalvrz to verify the fix against his #580 data. On confirmation, kitconcept.solr #113 gets merged first; this PR's merge is then Dante's call (after the merge the pin can be moved to the then-current feature-ai-rag revision, or kept — content-wise identical).