### PR TITLE
Switch kitconcept.solr to the released 3.0.0a0 (AI RAG support)

### DIFF
--- a/backend/news/595.feature
+++ b/backend/news/595.feature
@@ -1,0 +1,1 @@
+Use the released kitconcept.solr==3.0.0a0 from PyPI (with AI/RAG search support) instead of the pinned git revision. @reebalazs

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pas.plugins.keycloakgroups==1.0.0b1",
     "pas.plugins.oidc==2.0.0",
     "collective-solr==10.1.1",
-    "kitconcept.solr",
+    "kitconcept.solr==3.0.0a0",
     "kitconcept.contactblock==1.0.0a6",
     "kitconcept.plate==1.0.0a23",
 ]
@@ -66,7 +66,6 @@ container = [
 ]
 
 [tool.uv.sources]
-kitconcept-solr = { git = "https://github.com/kitconcept/kitconcept.solr.git", subdirectory = "backend", rev = "a8953cefb2d250bb83213bef0099ffceda87dc78" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.14.*"
 
 [options]
@@ -1520,7 +1520,7 @@ requires-dist = [
     { name = "kitconcept-contactblock", specifier = "==1.0.0a6" },
     { name = "kitconcept-core", specifier = "==2.0.0b4" },
     { name = "kitconcept-plate", specifier = "==1.0.0a23" },
-    { name = "kitconcept-solr", git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&rev=a8953cefb2d250bb83213bef0099ffceda87dc78" },
+    { name = "kitconcept-solr", specifier = "==3.0.0a0" },
     { name = "pas-plugins-authomatic", specifier = "==2.0.0" },
     { name = "pas-plugins-keycloakgroups", specifier = "==1.0.0b1" },
     { name = "pas-plugins-oidc", specifier = "==2.0.0" },
@@ -1574,8 +1574,8 @@ wheels = [
 
 [[package]]
 name = "kitconcept-solr"
-version = "2.0.0a14"
-source = { git = "https://github.com/kitconcept/kitconcept.solr.git?subdirectory=backend&rev=a8953cefb2d250bb83213bef0099ffceda87dc78#a8953cefb2d250bb83213bef0099ffceda87dc78" }
+version = "3.0.0a0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "collective-solr" },
     { name = "plone-api" },
@@ -1584,6 +1584,10 @@ dependencies = [
     { name = "plone-volto" },
     { name = "products-cmfplone" },
     { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/fb/6639b19d581f8e639b2229c155428566f556b0554d505896fb3453deddde/kitconcept_solr-3.0.0a0.tar.gz", hash = "sha256:900ec73e5248e2603b1a8ed871736ed30ba8aad7131a099c44eb040109ccb3aa", size = 18745940, upload-time = "2026-08-24T07:17:11.38Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/3e/53448dd411645cee1b61ffdf3dc285d8c971201649fc43c8c0ecfae29c4e/kitconcept_solr-3.0.0a0-py3-none-any.whl", hash = "sha256:f01337d5b081e954f23ba1e5f8a7a9d8ee16b4c405aea6eb1238f654e7deb667", size = 18987698, upload-time = "2026-08-24T07:17:06.844Z" },
 ]
 
 [[package]]

--- a/devops/stacks/demo.yml
+++ b/devops/stacks/demo.yml
@@ -97,7 +97,7 @@ services:
           - ${STACK_NAME}-tika
 
   solr:
-    image: ghcr.io/kitconcept/solr:${SOLR_TAG:-sha-826383b}
+    image: ghcr.io/kitconcept/solr:${SOLR_TAG:-3.0.0a0}
     command:
       - solr-precreate
       - plone

--- a/devops/stacks/persistent.yml
+++ b/devops/stacks/persistent.yml
@@ -132,7 +132,7 @@ services:
           - ${STACK_NAME}-tika
 
   solr:
-    image: ghcr.io/kitconcept/solr:${SOLR_TAG:-sha-826383b}
+    image: ghcr.io/kitconcept/solr:${SOLR_TAG:-3.0.0a0}
     command:
       - solr-precreate
       - plone

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -52,7 +52,7 @@ x-tika: &tika
     - 9998:9998
 
 x-solr: &solr
-  image: ghcr.io/kitconcept/solr:${SOLR_TAG:-sha-826383b}
+  image: ghcr.io/kitconcept/solr:${SOLR_TAG:-3.0.0a0}
   platform: linux/amd64
   ports:
     - 8983:8983

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -64,7 +64,9 @@ module.exports = {
           ],
           [
             '@kitconcept/volto-solr',
-            './packages/volto-solr/frontend/packages/volto-solr/src',
+            // installed from npm; pnpm links it into the consuming
+            // package's node_modules
+            './packages/kitconcept-intranet/node_modules/@kitconcept/volto-solr/src',
           ],
           ...addonAliases,
         ],

--- a/frontend/mrs.developer.json
+++ b/frontend/mrs.developer.json
@@ -128,15 +128,6 @@
     "https": "https://github.com/plone/form-block.git",
     "tag": "1.0.0-alpha.3"
   },
-  "volto-solr": {
-    "develop": true,
-    "output": "packages",
-    "package": "@kitconcept/volto-solr",
-    "url": "git@github.com:kitconcept/kitconcept.solr.git",
-    "https": "https://github.com/kitconcept/kitconcept.solr.git",
-    "path": "frontend/packages/volto-solr",
-    "tag": "a8953cefb2d250bb83213bef0099ffceda87dc78"
-  },
   "volto-contact-block": {
     "develop": true,
     "output": "packages",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,6 @@
       "@kitconcept/volto-carousel-block": "workspace:*",
       "@kitconcept/volto-iframe-block": "workspace:*",
       "@kitconcept/volto-bm3-compat": "workspace:*",
-      "@kitconcept/volto-solr": "workspace:*",
       "@plone/registry": "workspace:*",
       "react-aria-components": "catalog:"
     },

--- a/frontend/packages/kitconcept-intranet/news/595.feature
+++ b/frontend/packages/kitconcept-intranet/news/595.feature
@@ -1,0 +1,1 @@
+Use the released @kitconcept/volto-solr ^3.0.0-alpha.0 from npm instead of the mrs.developer checkout. @reebalazs

--- a/frontend/packages/kitconcept-intranet/package.json
+++ b/frontend/packages/kitconcept-intranet/package.json
@@ -88,7 +88,7 @@
     "@kitconcept/volto-separator-block": "workspace:*",
     "@kitconcept/volto-slider-block": "workspace:*",
     "@plonegovbr/volto-social-media": "^2.0.0-alpha.10",
-    "@kitconcept/volto-solr": "workspace:*",
+    "@kitconcept/volto-solr": "^3.0.0-alpha.0",
     "@kitconcept/volto-iframe-block": "workspace:*",
     "@kitconcept/volto-light-theme": "workspace:*",
     "@kitconcept/volto-contact-block": "workspace:*",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -113,7 +113,6 @@ overrides:
   '@kitconcept/volto-carousel-block': workspace:*
   '@kitconcept/volto-iframe-block': workspace:*
   '@kitconcept/volto-bm3-compat': workspace:*
-  '@kitconcept/volto-solr': workspace:*
   '@plone/registry': workspace:*
   react-aria-components: ^1.17.0
 
@@ -1454,8 +1453,8 @@ importers:
         specifier: workspace:*
         version: link:../volto-slider-block/packages/volto-slider-block
       '@kitconcept/volto-solr':
-        specifier: workspace:*
-        version: link:../volto-solr/frontend/packages/volto-solr
+        specifier: ^3.0.0-alpha.0
+        version: 3.0.0-alpha.0(react-autosuggest@10.1.0(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@plone-collective/volto-authomatic':
         specifier: 3.0.0-alpha.6
         version: 3.0.0-alpha.6(@plone/components@core+packages+components)(@plone/registry@core+packages+registry)(react-dom@18.2.0(react@18.2.0))(react-intl@3.12.1(@types/react@18.3.31)(react@18.2.0))(react@18.2.0)(semantic-ui-react@2.1.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -2208,71 +2207,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.1)(@vitest/ui@3.2.6)(jiti@2.7.0)(jsdom@28.1.0(@noble/hashes@1.8.0))(less@3.13.1)(lightningcss@1.32.0)(sass@1.58.0)(terser@5.48.0)(yaml@2.9.0)
-
-  packages/volto-social-media/frontend/packages/volto-social-media:
-    dependencies:
-      '@plone/components':
-        specifier: workspace:*
-        version: link:../../../../../core/packages/components
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: 18.2.0
-        version: 18.2.0(react@18.2.0)
-    devDependencies:
-      '@plone/scripts':
-        specifier: ^3.6.2
-        version: 3.10.6
-      '@plone/types':
-        specifier: workspace:*
-        version: link:../../../../../core/packages/types
-      '@types/jest':
-        specifier: ^29.5.8
-        version: 29.5.14
-      '@types/lodash':
-        specifier: ^4.14.201
-        version: 4.17.24
-      '@types/react':
-        specifier: ^18.3.12
-        version: 18.3.31
-      '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.7(@types/react@18.3.31)
-      react-intl:
-        specifier: ^3.12.1
-        version: 3.12.1(@types/react@18.3.31)(react@18.2.0)
-      release-it:
-        specifier: ^17.7.0
-        version: 17.11.0(typescript@5.9.3)
-
-  packages/volto-solr/frontend/packages/volto-solr:
-    dependencies:
-      buffer:
-        specifier: ^5.5.0
-        version: 5.7.1
-      lodash.debounce:
-        specifier: ^4.0.8
-        version: 4.0.8
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: 18.2.0
-        version: 18.2.0(react@18.2.0)
-      react-portal:
-        specifier: 4.2.1
-        version: 4.2.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-    devDependencies:
-      '@plone/scripts':
-        specifier: ^3.6.1
-        version: 3.10.6
-      react-autosuggest:
-        specifier: 10.1.0
-        version: 10.1.0(react@18.2.0)
-      release-it:
-        specifier: ^17.1.1
-        version: 17.11.0(typescript@5.9.3)
 
 packages:
 
@@ -4221,6 +4155,13 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0
       semantic-ui-react: ^2.1.5
+
+  '@kitconcept/volto-solr@3.0.0-alpha.0':
+    resolution: {integrity: sha512-Niv4gQ3WxycvKil4oGoxlnp1Cpx0ONOLjh13qKY3djzDXpZK1o0whQF8S0O9IyFvmMMV6Peq0waKAsmNpyNINQ==}
+    peerDependencies:
+      react: 18.2.0
+      react-autosuggest: 10.1.0
+      react-dom: 18.2.0
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -16439,6 +16380,15 @@ snapshots:
       - supports-color
       - typescript
       - use-sync-external-store
+
+  '@kitconcept/volto-solr@3.0.0-alpha.0(react-autosuggest@10.1.0(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      buffer: 5.7.1
+      lodash.debounce: 4.0.8
+      react: 18.2.0
+      react-autosuggest: 10.1.0(react@18.2.0)
+      react-dom: 18.2.0(react@18.2.0)
+      react-portal: 4.2.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
   '@kwsites/file-exists@1.1.1':
     dependencies:

--- a/news/595.feature
+++ b/news/595.feature
@@ -1,0 +1,1 @@
+Switch kitconcept.solr to the released 3.0.0a0, with AI (RAG) search support: kitconcept.solr==3.0.0a0 from PyPI (replacing the pinned git revision), @kitconcept/volto-solr ^3.0.0-alpha.0 from npm (replacing the mrs.developer checkout), and the 3.0.0a0 Solr image in the dev compose and stack files. @reebalazs


### PR DESCRIPTION
Ticket: https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-intranet/-/work_items/595

Switches kitconcept.solr from the pinned feature-branch git revision to the released **3.0.0a0**, which carries the AI (RAG) search support and the search filter backend:

- **Backend**: `kitconcept.solr==3.0.0a0` from PyPI; the `tool.uv.sources` git entry is removed; `uv.lock` re-resolved.
- **Frontend**: `@kitconcept/volto-solr ^3.0.0-alpha.0` from npm; the mrs.developer checkout and the workspace override are removed; `pnpm-lock.yaml` regenerated.
- **Solr image**: default tag `3.0.0a0` in `docker-compose-dev.yml` and the `devops/stacks` files (image verified present on ghcr).

This PR contains **only** the switch, so it can be merged and deployed to staging on its own. The search-dialog filter chips PR #478 carries the same switch commit as its second commit — the two PRs are verified to merge cleanly in either order, so you can take just this one, or both.