### PR TITLE
Scope sidebar top offset to the compact intranet header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,16 @@ Use the Cypress path mainly to maintain or debug existing legacy specs under `fr
 - Be careful with `mrs.developer.json`, local workspace overrides, and the vendored/frontend core relationship.
 - When changing frontend behavior, consider whether the change belongs in `frontend/packages/kitconcept-intranet` or in the vendored Volto core area.
 - When changing exported backend content or distribution setup, verify whether the change affects demo data, installation defaults, or test fixtures.
+
+## Changelog Fragments
+
+This repo checks for towncrier fragments in CI.
+
+- Backend changes need a fragment under `backend/news/`
+- Frontend add-on changes need a fragment under `frontend/packages/kitconcept-intranet/news/`
+- Repo-level (not related to `backend` or `frontend`) changes may need a fragment under the root `news/`
+
+## PR Guidance
+
+- Create a PR only when you are told to
+- After creating a PR, make sure that a Towncrier fragment is present for the change, and that it is in the correct location. Create it/them if needed following the Changelog Fragments guidance section.

--- a/frontend/packages/kitconcept-intranet/news/+header-sidebar-offset.bugfix
+++ b/frontend/packages/kitconcept-intranet/news/+header-sidebar-offset.bugfix
@@ -1,0 +1,1 @@
+Scope the sidebar top offset to the compact intranet header via a body class, so the sidebar is only pushed down when that header is present. @sneridagh

--- a/frontend/packages/kitconcept-intranet/src/components/Header/Header.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/Header/Header.tsx
@@ -66,7 +66,7 @@ const Header = (props) => {
 
   return (
     <>
-      <BodyClass className="header-intranet-compact" />
+      <BodyClass className="has-header-intranet-compact" />
       <div className="header-intranet-compact-wrapper">
         <div
           className={cx('header-intranet-compact', {

--- a/frontend/packages/kitconcept-intranet/src/components/Header/Header.tsx
+++ b/frontend/packages/kitconcept-intranet/src/components/Header/Header.tsx
@@ -4,6 +4,7 @@ import config from '@plone/volto/registry';
 import HeaderBreadcrumbs from './HeaderBreadcrumbs';
 import HeaderSearch from './HeaderSearch';
 import cx from 'classnames';
+import BodyClass from '@plone/volto/helpers/BodyClass/BodyClass';
 
 type HeaderState = {
   content: {
@@ -64,16 +65,19 @@ const Header = (props) => {
   }
 
   return (
-    <div className="header-intranet-compact-wrapper">
-      <div
-        className={cx('header-intranet-compact', {
-          'is-route-transition': isRouteTransition,
-        })}
-      >
-        <HeaderBreadcrumbs pathname={pathname} />
-        <HeaderSearch />
+    <>
+      <BodyClass className="header-intranet-compact" />
+      <div className="header-intranet-compact-wrapper">
+        <div
+          className={cx('header-intranet-compact', {
+            'is-route-transition': isRouteTransition,
+          })}
+        >
+          <HeaderBreadcrumbs pathname={pathname} />
+          <HeaderSearch />
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/frontend/packages/kitconcept-intranet/src/theme/header.scss
+++ b/frontend/packages/kitconcept-intranet/src/theme/header.scss
@@ -886,7 +886,7 @@ $search-text: #252525;
 }
 
 //
-.sidebar-container {
+body.has-header-intranet-compact .sidebar-container {
   top: var(--topbar-height);
   height: calc(100vh - var(--topbar-height));
 }

--- a/news/+agents-changelog-pr-guidance.documentation
+++ b/news/+agents-changelog-pr-guidance.documentation
@@ -1,0 +1,1 @@
+Document changelog fragment locations and PR guidance for agents in AGENTS.md. @sneridagh


### PR DESCRIPTION
## What

Fixes the sidebar top offset so it is only applied when the compact intranet header is present.

- Render a `BodyClass` (`header-intranet-compact`) from the compact `Header` component.
- Scope the `.sidebar-container` `top`/`height` rules to `body.has-header-intranet-compact` in `header.scss`, so the sidebar is only pushed down by `--topbar-height` when that header is actually rendered.

Also documents changelog fragment locations and PR guidance for agents in `AGENTS.md`.

## Changelog

- `frontend/packages/kitconcept-intranet/news/+header-sidebar-offset.bugfix`
- `news/+agents-changelog-pr-guidance.documentation`